### PR TITLE
feat: Add silence detection and improve format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,41 @@ Audio DeSilencer is a powerful Python package for audio processing that empowers
 
 - **Text File Generation**: Create text files containing the timeline data of silent and non-silent parts, facilitating further processing for video silence removal or in-depth analysis.
 
+- **Wide Format Support**: Now supports a wider range of audio formats, including MP4A, OGG, FLAC, WAV, MP3, and more, as supported by FFmpeg, thanks to automatic format detection.
+
 - **Command-Line Interface**: Seamlessly integrate Audio DeSilencer into your audio and video processing pipelines with an intuitive command-line interface.
+
+### Checking for Full Silence
+
+The `AudioProcessor` class now includes a method to check if an audio file is completely silent.
+
+**`is_fully_silent(min_silence_len=100, threshold=-30)`**
+
+-   `min_silence_len` (int): The minimum duration (in milliseconds) that a segment of audio must have to be considered non-silent. Default is 100 ms.
+-   `threshold` (int): The audio level (in dBFS) below which audio is considered silent. Default is -30 dBFS.
+-   **Returns**: `True` if no non-silent segments are found (i.e., the entire audio is below the `threshold` for durations longer than `min_silence_len`), `False` otherwise.
+
+**Example:**
+
+```python
+from audio_desilencer.audio_processor import AudioProcessor
+
+# Initialize the processor with your audio file
+# Supports MP4A, WAV, MP3, and other ffmpeg-supported formats
+processor = AudioProcessor("path/to/your/audiofile.m4a")
+
+# Check if the audio is fully silent using default parameters
+if processor.is_fully_silent():
+    print("The audio file is completely silent.")
+else:
+    print("The audio file contains non-silent parts.")
+
+# Or with custom parameters
+if processor.is_fully_silent(min_silence_len=200, threshold=-40):
+    print("The audio file is completely silent (using custom settings).")
+else:
+    print("The audio file contains non-silent parts (using custom settings).")
+```
 
 ## Installation
 

--- a/audio_desilencer/audio_processor.py
+++ b/audio_desilencer/audio_processor.py
@@ -6,7 +6,7 @@ from pydub.silence import detect_nonsilent
 class AudioProcessor:
     def __init__(self, input_file_path):
         self.input_file_path = input_file_path
-        self.audio = AudioSegment.from_file(input_file_path, format="mp3")
+        self.audio = AudioSegment.from_file(input_file_path)
 
     def split_audio_by_silence(self, min_silence_len, threshold):
         return detect_nonsilent(self.audio, min_silence_len=min_silence_len, silence_thresh=threshold)
@@ -22,6 +22,12 @@ class AudioProcessor:
                 file.write(f"({start}, {end}), ")
             file.write("]")
         print(f"Saved timeline data to {output_path}")
+
+    def is_fully_silent(self, min_silence_len=100, threshold=-30):
+        # Detect non-silent parts
+        non_silent_segments = self.split_audio_by_silence(min_silence_len, threshold)
+        # If the list of non-silent segments is empty, the audio is fully silent
+        return not non_silent_segments
 
     def process_audio(self, min_silence_len=100, threshold=-30, output_folder='output'):
         try:

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from audio_desilencer.audio_processor import AudioProcessor
+# Import pydub.silence if you are directly patching detect_nonsilent from there
+# from pydub.silence import detect_nonsilent
+
+class TestAudioProcessor(unittest.TestCase):
+
+    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
+    @patch('audio_desilencer.audio_processor.detect_nonsilent')
+    def test_is_fully_silent_when_audio_is_silent(self, mock_detect_nonsilent, mock_from_file):
+        # Configure mocks
+        mock_audio_segment = MagicMock()
+        mock_from_file.return_value = mock_audio_segment
+        mock_detect_nonsilent.return_value = []  # Simulate full silence
+
+        # Instantiate AudioProcessor
+        processor = AudioProcessor("dummy.mp4a")
+
+        # Call is_fully_silent and assert
+        self.assertTrue(processor.is_fully_silent())
+        mock_from_file.assert_called_once_with("dummy.mp4a")
+        mock_detect_nonsilent.assert_called_once_with(mock_audio_segment, min_silence_len=100, silence_thresh=-30)
+
+    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
+    @patch('audio_desilencer.audio_processor.detect_nonsilent')
+    def test_is_fully_silent_when_audio_is_not_silent(self, mock_detect_nonsilent, mock_from_file):
+        # Configure mocks
+        mock_audio_segment = MagicMock()
+        mock_from_file.return_value = mock_audio_segment
+        mock_detect_nonsilent.return_value = [[0, 1000]]  # Simulate non-silent segments
+
+        # Instantiate AudioProcessor
+        processor = AudioProcessor("dummy.wav")
+
+        # Call is_fully_silent and assert
+        self.assertFalse(processor.is_fully_silent())
+        mock_from_file.assert_called_once_with("dummy.wav")
+        mock_detect_nonsilent.assert_called_once_with(mock_audio_segment, min_silence_len=100, silence_thresh=-30)
+
+    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
+    def test_audio_processor_init_format_detection(self, mock_from_file):
+        # Configure mock
+        mock_audio_segment = MagicMock()
+        mock_from_file.return_value = mock_audio_segment
+
+        # Instantiate AudioProcessor
+        processor = AudioProcessor("dummy.m4a")
+
+        # Assert that from_file was called correctly (without format)
+        mock_from_file.assert_called_once_with("dummy.m4a")
+        # Check that 'format' was not in the kwargs or was None
+        # called_args, called_kwargs = mock_from_file.call_args
+        # self.assertNotIn('format', called_kwargs) # This is one way
+        # Or, more simply, if no other args are expected:
+        # self.assertEqual(called_args, ("dummy.m4a",))
+        # self.assertEqual(called_kwargs, {})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces new functionality to check if an audio file is fully silent and enhances audio format compatibility.

Key changes:
- Modified `AudioProcessor` to auto-detect input audio formats (e.g., MP4A, WAV, OGG, FLAC), removing the previous MP3-only limitation.
- Added a new method `is_fully_silent(min_silence_len, threshold)` to `AudioProcessor` that returns True if the entire audio file is determined to be silent based on the given parameters, and False otherwise.
- Included unit tests for the new `is_fully_silent` method and the format detection update, utilizing mocking for robust testing.
- Updated `README.md` to reflect the enhanced format support and to document the `is_fully_silent` method with usage examples.

This addresses your request to determine if an MP4A file is fully silent and integrate this capability into your Python application.