### PR TITLE
🔒 Remove standard library argparse from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pydub',
-        'argparse',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
🎯 **What:** Removed `argparse` from `install_requires` in `setup.py`.

⚠️ **Risk:** `argparse` is a standard library module in Python. Including it in PyPI dependencies can lead to dependency confusion attacks, where a malicious package with the same name could be downloaded from an external registry, compromising the codebase or its users.

🛡️ **Solution:** Removed `'argparse'` from the `install_requires` list. It is already available built-in with Python, so functionality remains unchanged and the vulnerability is mitigated.

---
*PR created automatically by Jules for task [9808625296086011696](https://jules.google.com/task/9808625296086011696) started by @BTawaifi*