### PR TITLE
🧪 [Add test for save_audio function]

### DIFF
--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -57,6 +57,28 @@ class TestAudioProcessor(unittest.TestCase):
         mock_from_file.assert_called_once_with("dummy.m4a")
 
     @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
+    @patch('builtins.print')
+    def test_save_audio(self, mock_print, mock_from_file):
+        # Configure mock for init
+        mock_audio_segment = MagicMock()
+        mock_from_file.return_value = mock_audio_segment
+
+        processor = AudioProcessor("dummy.mp3")
+
+        # Create mock audio object
+        mock_audio = MagicMock()
+        output_path = "output.mp3"
+
+        # Call the method
+        processor.save_audio(mock_audio, output_path)
+
+        # Assert export was called correctly
+        mock_audio.export.assert_called_once_with(output_path, format="mp3")
+
+        # Assert print was called correctly
+        mock_print.assert_called_once_with(f"Saved audio to {output_path}")
+
+    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
     def test_save_timeline_to_text(self, mock_from_file):
         # Configure mock for init
         mock_audio_segment = MagicMock()


### PR DESCRIPTION
🎯 **What:** The `save_audio` function in `AudioProcessor` was untested. Added a unit test to verify its behavior.
📊 **Coverage:** Tests the happy path of `save_audio`, verifying that `audio.export` is called with the correct output path and format, and that the success message is printed to stdout.
✨ **Result:** Improved test coverage by covering the previously untested `save_audio` function and asserting correct call signatures and expected stdout prints.

---
*PR created automatically by Jules for task [11016727988351962841](https://jules.google.com/task/11016727988351962841) started by @BTawaifi*