### PR TITLE
🧪 Add tests for main function in audio_processor.py

### DIFF
--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -153,6 +153,38 @@ class TestAudioProcessor(unittest.TestCase):
             self.assertIn(expected_non_silent_raw, actual_spawn_data)
             self.assertIn(expected_silent_raw, actual_spawn_data)
 
+    @patch('audio_desilencer.audio_processor.AudioProcessor')
+    @patch('sys.argv', ['audio_desilencer', 'input.mp3', '--output_folder', 'test_out', '--min_silence_len', '200', '--threshold', '-40'])
+    def test_main_custom_args(self, mock_audio_processor):
+        from audio_desilencer.audio_processor import main
+        mock_processor_instance = MagicMock()
+        mock_audio_processor.return_value = mock_processor_instance
+
+        main()
+
+        mock_audio_processor.assert_called_once_with('input.mp3')
+        mock_processor_instance.process_audio.assert_called_once_with(
+            min_silence_len=200,
+            threshold=-40,
+            output_folder='test_out'
+        )
+
+    @patch('audio_desilencer.audio_processor.AudioProcessor')
+    @patch('sys.argv', ['audio_desilencer', 'input.mp3'])
+    def test_main_defaults(self, mock_audio_processor):
+        from audio_desilencer.audio_processor import main
+        mock_processor_instance = MagicMock()
+        mock_audio_processor.return_value = mock_processor_instance
+
+        main()
+
+        mock_audio_processor.assert_called_once_with('input.mp3')
+        mock_processor_instance.process_audio.assert_called_once_with(
+            min_silence_len=100,
+            threshold=-30,
+            output_folder='output'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `main` function in `audio_processor.py` was completely untested, leaving argument parsing and application startup unverified.
📊 **Coverage:** We now test the `main` function using `unittest.mock.patch` for `sys.argv` and `AudioProcessor`. We cover two scenarios: one with default arguments and one with custom CLI arguments (`--output_folder`, `--min_silence_len`, `--threshold`).
✨ **Result:** Increased test coverage by ensuring the main entry point logic is correctly parsing CLI arguments and passing them down to the `AudioProcessor.process_audio` method.

---
*PR created automatically by Jules for task [12692478333031235639](https://jules.google.com/task/12692478333031235639) started by @BTawaifi*