### PR TITLE
🧹 [Avoid catching broad Exception in process_audio]

### DIFF
--- a/audio_desilencer/audio_processor.py
+++ b/audio_desilencer/audio_processor.py
@@ -81,7 +81,7 @@ class AudioProcessor:
             print("Silent parts timeline saved to:", silent_txt_path)
             print("Non-silent parts timeline saved to:", non_silent_txt_path)
 
-        except Exception as e:
+        except (OSError, ValueError) as e:
             print("An error occurred:", str(e))
 
 def main():


### PR DESCRIPTION
🎯 What: Replaced a broad `Exception` catch block in `audio_processor.py` with more specific exceptions (`OSError`, `ValueError`).
💡 Why: Catching broad exceptions is an anti-pattern as it can silently swallow unexpected bugs like `NameError` or `TypeError`, making debugging significantly harder.
✅ Verification: Ran the existing test suite (`python3 -m unittest discover tests`) to confirm that all current functionality and error handling behavior remains intact without side effects.
✨ Result: Improved error handling robustness and overall codebase maintainability without breaking any existing functionality.

---
*PR created automatically by Jules for task [3818980118839036064](https://jules.google.com/task/3818980118839036064) started by @BTawaifi*