### PR TITLE
fix: harden silence processing, API, packaging, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     runs-on: ubuntu-latest
@@ -26,7 +27,47 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package
-        run: python -m pip install --upgrade pip && python -m pip install -e .
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
 
-      - name: Run tests
+      - name: Verify dependency consistency
+        run: python -m pip check
+
+      - name: Run regression suite
         run: python -m unittest discover -s tests -v
+
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Build wheel and source distribution
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Verify wheel contents
+        run: |
+          python - <<'PY'
+          import glob
+          import zipfile
+          wheel = glob.glob('dist/*.whl')[0]
+          with zipfile.ZipFile(wheel) as archive:
+              assert not any(name.startswith('tests/') for name in archive.namelist())
+          PY
+
+      - name: Install built wheel
+        run: python -m pip install dist/*.whl
+
+      - name: Verify installed API and CLI
+        run: |
+          python -c "from audio_desilencer import AudioProcessor, ProcessingResult, complement_ranges; assert complement_ranges(10, [(2, 8)]) == [(0, 2), (8, 10)]"
+          audio-desilencer --help

--- a/README.md
+++ b/README.md
@@ -1,21 +1,101 @@
 # Audio DeSilencer
 
-Audio DeSilencer is a Python package and CLI for detecting silence in audio, removing silent segments, and exporting timing data for downstream audio/video workflows.
+Audio DeSilencer is a small Python package and CLI for detecting silent/non-silent regions, separating those regions into output audio files, and exporting the corresponding timelines.
 
 ```bash
 pip install audio-desilencer
 ```
 
-The project is intentionally small: it wraps a concrete audio-processing workflow behind both a Python API and a command-line interface rather than requiring users to script FFmpeg/pydub behavior themselves.
-
 ## Features
 
-- Detect silent and non-silent regions using configurable thresholds
-- Remove detected silence from audio
-- Export silent/non-silent timeline data
-- Detect fully silent files
-- Support formats handled by FFmpeg/pydub, including MP3, WAV, FLAC, OGG, and M4A/MP4A
-- Use the same functionality through Python or the CLI
+- Detect non-silent ranges with configurable dBFS and minimum-silence thresholds
+- Correctly derive the complete silent complement, including leading and trailing silence
+- Handle fully silent and fully non-silent files without dropping audio
+- Export separate silent and non-silent audio files
+- Export the exact silent/non-silent millisecond timelines
+- Choose the output codec/extension instead of forcing every result to MP3
+- Use either the Python API or the `audio-desilencer` CLI
+- Return a structured `ProcessingResult` to Python callers
+
+Codec support is provided by pydub/FFmpeg. Formats that require FFmpeg still depend on FFmpeg being installed and available on the host system.
+
+## Silence model
+
+Silence detection is controlled by:
+
+- `threshold`: audio below this dBFS level is considered silent
+- `min_silence_len`: minimum duration in milliseconds before a region counts as silence
+
+The processor first obtains non-silent ranges and then computes their complement across the full audio duration. That means leading, internal, and trailing silence are represented consistently.
+
+## CLI
+
+```bash
+audio-desilencer input_audio.mp3 \
+  --output_folder output \
+  --min_silence_len 100 \
+  --threshold -30 \
+  --output_format mp3
+```
+
+Optional custom output stem:
+
+```bash
+audio-desilencer interview.m4a --output_stem cleaned --output_format wav
+```
+
+For an input named `interview.m4a`, the default output names are:
+
+```text
+interview_silent.mp3
+interview_non_silent.mp3
+interview_silent_parts.txt
+interview_non_silent_parts.txt
+```
+
+The CLI returns a non-zero exit status when loading or processing fails instead of printing an error and appearing successful.
+
+## Python API
+
+```python
+from audio_desilencer import AudioProcessor
+
+processor = AudioProcessor("input.m4a")
+result = processor.process_audio(
+    min_silence_len=200,
+    threshold=-40,
+    output_folder="output",
+    output_format="wav",
+)
+
+print(result.silent_ranges)
+print(result.non_silent_ranges)
+print(result.non_silent_audio_path)
+```
+
+You can also use the detection layer directly:
+
+```python
+segments = processor.split_audio_by_silence(
+    min_silence_len=200,
+    threshold=-40,
+)
+
+if processor.is_fully_silent():
+    print("No non-silent audio detected")
+```
+
+`process_audio()` raises processing errors to Python callers. Friendly error reporting is kept at the CLI boundary so library code can reliably distinguish success from failure.
+
+## Timeline format
+
+Timeline files contain a Python-literal list of `(start_ms, end_ms)` tuples:
+
+```text
+[(0, 1200), (3400, 5100)]
+```
+
+Ranges are clamped, sorted, merged when necessary, and never include zero-length intervals.
 
 ## Architecture
 
@@ -24,120 +104,60 @@ CLI / Python caller
         │
         ▼
 AudioProcessor
-├── load audio through pydub
+├── load through pydub
 ├── detect non-silent ranges
-├── derive silent ranges
-├── export processed audio
+├── normalize ranges
+├── compute silent complement over full duration
+├── concatenate selected source slices
+├── export audio
 └── write timing metadata
         │
         ▼
-FFmpeg-backed codec support
+FFmpeg-backed codec support where required
 ```
 
-The core processing logic lives in the package rather than in the CLI entry point, so command-line use and programmatic use share the same behavior.
+The processing layer is shared by the CLI and Python API. Output naming is derived from the input stem by default, so processing multiple files into the same output folder does not overwrite a generic `interview_*` filename.
 
-## Why pydub + FFmpeg
+## Testing
 
-The package delegates codec handling to mature tooling instead of implementing decoders itself.
+The regression suite contains both pure interval tests and tests that use real pydub `AudioSegment` data. It specifically covers:
 
-**Benefit:** broad input-format support and a much smaller codebase.
+- leading, internal, and trailing silence
+- fully silent audio
+- fully non-silent audio
+- range clamping/sorting/merging
+- real tone-vs-silence detection
+- output naming and codec selection
+- timeline serialization
+- CLI success/failure exit behavior
+- package API behavior
 
-**Cost:** runtime behavior ultimately depends on FFmpeg availability for formats that require it.
-
-## Silence detection model
-
-Silence is determined from two main parameters:
-
-- `threshold`: audio below this dBFS level is considered silent
-- `min_silence_len`: minimum duration required before a region is treated as silence
-
-Those values are intentionally caller-configurable because there is no universal threshold that works equally well for speech, music, noisy recordings, and studio audio.
-
-## Python usage
-
-```python
-from audio_desilencer.audio_processor import AudioProcessor
-
-processor = AudioProcessor("input.m4a")
-
-if processor.is_fully_silent():
-    print("No meaningful audio detected")
-
-segments = processor.split_audio_by_silence(
-    min_silence_len=200,
-    threshold=-40,
-)
-```
-
-## CLI usage
-
-```bash
-audio-desilencer input_audio.mp3 \
-  --output_folder output \
-  --min_silence_len 100 \
-  --threshold -30
-```
-
-Typical output includes processed audio plus text files describing silent and non-silent intervals.
-
-## Testing strategy
-
-The repository includes a `unittest` suite around the processing layer. External audio/codec behavior is mocked where appropriate so core segmentation and error-handling logic can be tested deterministically without depending on large media fixtures.
-
-CI runs the suite across multiple Python versions on pushes and pull requests:
+Run locally:
 
 ```bash
 python -m unittest discover -s tests -v
 ```
 
-This keeps package behavior verifiable independently from a developer's local FFmpeg installation.
-
-## Engineering tradeoffs
-
-### Timing metadata as plain text
-
-**Benefit:** simple to inspect, script, and feed into video-editing workflows.
-
-**Cost:** it is less structured than JSON or a typed interchange format.
-
-### Threshold-based detection
-
-**Benefit:** deterministic, fast, explainable, and user-tunable.
-
-**Cost:** it does not attempt semantic speech/music detection and therefore needs appropriate threshold configuration for noisy recordings.
-
-### Lightweight package surface
-
-**Benefit:** easy installation and a small API.
-
-**Cost:** advanced workflows such as VAD models, streaming processing, batch orchestration, or GUI editing are intentionally outside the core package.
-
-## Known limitations
-
-- Results depend heavily on the chosen silence threshold and minimum duration.
-- Codec support depends on the local FFmpeg/pydub environment.
-- The package is designed for file-based processing, not real-time audio streams.
-- It does not attempt ML-based voice activity detection.
+GitHub Actions runs the suite on Python 3.10, 3.11, 3.12, and 3.13. A separate packaging job builds the wheel/source distribution, installs the wheel, verifies imports, and exercises the installed CLI.
 
 ## Development
-
-Clone and install in editable mode:
 
 ```bash
 git clone https://github.com/BTawaifi/Audio-DeSilencer.git
 cd Audio-DeSilencer
-pip install -e .
-```
-
-Run tests:
-
-```bash
+python -m pip install -e .
 python -m unittest discover -s tests -v
 ```
 
-## Contributing
+The package declares Python 3.10+ support and excludes the repository's `tests` package from built distributions.
 
-Issues and pull requests are welcome. Changes to detection behavior should ideally include regression tests covering the relevant threshold/segment edge case.
+## Scope / limitations
+
+- Threshold-based silence detection is deterministic and explainable but not semantic voice-activity detection.
+- Results still depend on choosing a threshold appropriate for the recording.
+- File-based processing keeps decoded audio in memory; it is not a streaming engine.
+- Codec availability depends on the local pydub/FFmpeg environment.
+- The optimized concatenation path joins raw slices from the same source audio and therefore assumes matching audio parameters, which is true for slices produced by this processor.
 
 ## License
 

--- a/audio_desilencer/__init__.py
+++ b/audio_desilencer/__init__.py
@@ -1,0 +1,3 @@
+from .audio_processor import AudioProcessor, ProcessingResult, complement_ranges
+
+__all__ = ["AudioProcessor", "ProcessingResult", "complement_ranges"]

--- a/audio_desilencer/audio_processor.py
+++ b/audio_desilencer/audio_processor.py
@@ -1,100 +1,187 @@
-import os
+from __future__ import annotations
+
 import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
 from pydub import AudioSegment
+from pydub.exceptions import CouldntDecodeError, CouldntEncodeError
 from pydub.silence import detect_nonsilent
 
+
+Timeline = list[tuple[int, int]]
+
+
+@dataclass(frozen=True)
+class ProcessingResult:
+    silent_audio_path: str
+    non_silent_audio_path: str
+    silent_timeline_path: str
+    non_silent_timeline_path: str
+    silent_ranges: tuple[tuple[int, int], ...]
+    non_silent_ranges: tuple[tuple[int, int], ...]
+
+
+def _normalize_ranges(ranges: Iterable[Sequence[int]], total_duration: int) -> Timeline:
+    """Clamp, sort, and merge time ranges into non-overlapping millisecond intervals."""
+    total = max(0, int(total_duration))
+    normalized: Timeline = []
+
+    for raw in ranges:
+        if len(raw) != 2:
+            raise ValueError("Each timeline range must contain exactly two values")
+        start = max(0, min(total, int(raw[0])))
+        end = max(0, min(total, int(raw[1])))
+        if end <= start:
+            continue
+        normalized.append((start, end))
+
+    normalized.sort(key=lambda item: (item[0], item[1]))
+    merged: Timeline = []
+    for start, end in normalized:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            previous_start, previous_end = merged[-1]
+            merged[-1] = (previous_start, max(previous_end, end))
+    return merged
+
+
+def complement_ranges(total_duration: int, ranges: Iterable[Sequence[int]]) -> Timeline:
+    """Return the complement of ranges over [0, total_duration]."""
+    total = max(0, int(total_duration))
+    normalized = _normalize_ranges(ranges, total)
+    complement: Timeline = []
+    cursor = 0
+
+    for start, end in normalized:
+        if start > cursor:
+            complement.append((cursor, start))
+        cursor = max(cursor, end)
+
+    if cursor < total:
+        complement.append((cursor, total))
+    return complement
+
+
 class AudioProcessor:
-    def __init__(self, input_file_path):
-        self.input_file_path = input_file_path
-        self.audio = AudioSegment.from_file(input_file_path)
+    def __init__(self, input_file_path: str | os.PathLike[str]):
+        self.input_file_path = os.fspath(input_file_path)
+        self.audio = AudioSegment.from_file(self.input_file_path)
 
-    def split_audio_by_silence(self, min_silence_len, threshold):
-        return detect_nonsilent(self.audio, min_silence_len=min_silence_len, silence_thresh=threshold)
+    def split_audio_by_silence(self, min_silence_len: int, threshold: int) -> Timeline:
+        ranges = detect_nonsilent(
+            self.audio,
+            min_silence_len=min_silence_len,
+            silence_thresh=threshold,
+        )
+        return [(int(start), int(end)) for start, end in ranges]
 
-    def save_audio(self, audio, output_path):
-        audio.export(output_path, format="mp3")
+    def save_audio(self, audio: AudioSegment, output_path: str, output_format: str = "mp3") -> None:
+        audio.export(output_path, format=output_format)
         print(f"Saved audio to {output_path}")
 
-    def save_timeline_to_text(self, timeline_data, output_path):
-        with open(output_path, 'w') as file:
-            file.write("[")
-            for start, end in timeline_data:
-                file.write(f"({start}, {end}), ")
-            file.write("]")
+    def save_timeline_to_text(self, timeline_data: Iterable[Sequence[int]], output_path: str) -> None:
+        timeline = [(int(start), int(end)) for start, end in timeline_data]
+        with open(output_path, "w", encoding="utf-8") as file:
+            file.write(repr(timeline))
         print(f"Saved timeline data to {output_path}")
 
-    def is_fully_silent(self, min_silence_len=100, threshold=-30):
-        # Detect non-silent parts
-        non_silent_segments = self.split_audio_by_silence(min_silence_len, threshold)
-        # If the list of non-silent segments is empty, the audio is fully silent
-        return not non_silent_segments
+    def is_fully_silent(self, min_silence_len: int = 100, threshold: int = -30) -> bool:
+        return not self.split_audio_by_silence(min_silence_len, threshold)
 
-    def process_audio(self, min_silence_len=100, threshold=-30, output_folder='output'):
-        try:
-            print("Processing audio...")
-            non_silent_parts = self.split_audio_by_silence(min_silence_len, threshold)
-            silent_segments = []
-            non_silent_segments = []
-            silent_parts_times = []
-            non_silent_parts_times = []
+    def _join_ranges(self, ranges: Iterable[Sequence[int]]) -> AudioSegment:
+        segments = [self.audio[int(start):int(end)] for start, end in ranges if int(end) > int(start)]
+        if not segments:
+            return AudioSegment.empty()
+        return self.audio._spawn(b"".join(segment.raw_data for segment in segments))
 
-            for i, (start_time, end_time) in enumerate(non_silent_parts):
-                non_silent_segments.append(self.audio[start_time:end_time])
-                non_silent_parts_times.append((start_time, end_time))
+    def process_audio(
+        self,
+        min_silence_len: int = 100,
+        threshold: int = -30,
+        output_folder: str | os.PathLike[str] = "output",
+        output_format: str = "mp3",
+        output_stem: str | None = None,
+    ) -> ProcessingResult:
+        if min_silence_len <= 0:
+            raise ValueError("min_silence_len must be greater than zero")
+        normalized_format = output_format.strip().lower()
+        if not re.fullmatch(r"[a-z0-9]+", normalized_format):
+            raise ValueError("output_format must be a simple format name such as 'mp3' or 'wav'")
 
-                if i == 0:
-                    silent_start_time = 0
-                else:
-                    silent_start_time = non_silent_parts[i - 1][1]
-                silent_end_time = start_time
+        print("Processing audio...")
+        duration = len(self.audio)
+        non_silent_ranges = _normalize_ranges(
+            self.split_audio_by_silence(min_silence_len, threshold),
+            duration,
+        )
+        silent_ranges = complement_ranges(duration, non_silent_ranges)
 
-                silent_segments.append(self.audio[silent_start_time:silent_end_time])
-                silent_parts_times.append((silent_start_time, silent_end_time))
+        audio_silent = self._join_ranges(silent_ranges)
+        audio_non_silent = self._join_ranges(non_silent_ranges)
 
-            # Concatenate the audio segments efficiently by joining raw data
-            if silent_segments:
-                audio_silent = self.audio._spawn(b"".join(s.raw_data for s in silent_segments))
-            else:
-                audio_silent = AudioSegment.empty()
+        output_directory = Path(output_folder)
+        output_directory.mkdir(parents=True, exist_ok=True)
+        stem = output_stem or Path(self.input_file_path).stem or "audio"
+        safe_stem = Path(stem).name
+        if safe_stem in {"", ".", ".."}:
+            raise ValueError("output_stem must contain a valid filename stem")
 
-            if non_silent_segments:
-                audio_non_silent = self.audio._spawn(b"".join(s.raw_data for s in non_silent_segments))
-            else:
-                audio_non_silent = AudioSegment.empty()
+        silent_audio_path = output_directory / f"{safe_stem}_silent.{normalized_format}"
+        non_silent_audio_path = output_directory / f"{safe_stem}_non_silent.{normalized_format}"
+        silent_timeline_path = output_directory / f"{safe_stem}_silent_parts.txt"
+        non_silent_timeline_path = output_directory / f"{safe_stem}_non_silent_parts.txt"
 
-            # Create the output folder if it doesn't exist
-            os.makedirs(output_folder, exist_ok=True)
+        self.save_audio(audio_silent, str(silent_audio_path), normalized_format)
+        self.save_audio(audio_non_silent, str(non_silent_audio_path), normalized_format)
+        self.save_timeline_to_text(silent_ranges, str(silent_timeline_path))
+        self.save_timeline_to_text(non_silent_ranges, str(non_silent_timeline_path))
 
-            output_silent_path = os.path.join(output_folder, 'interview_silent.mp3')
-            output_non_silent_path = os.path.join(output_folder, 'interview_non_silent.mp3')
-            silent_txt_path = os.path.join(output_folder, 'silent_parts.txt')
-            non_silent_txt_path = os.path.join(output_folder, 'non_silent_parts.txt')
+        print("Audio processing completed.")
+        return ProcessingResult(
+            silent_audio_path=str(silent_audio_path),
+            non_silent_audio_path=str(non_silent_audio_path),
+            silent_timeline_path=str(silent_timeline_path),
+            non_silent_timeline_path=str(non_silent_timeline_path),
+            silent_ranges=tuple(silent_ranges),
+            non_silent_ranges=tuple(non_silent_ranges),
+        )
 
-            self.save_audio(audio_silent, output_silent_path)
-            self.save_audio(audio_non_silent, output_non_silent_path)
-            self.save_timeline_to_text(silent_parts_times, silent_txt_path)
-            self.save_timeline_to_text(non_silent_parts_times, non_silent_txt_path)
 
-            print("Audio processing completed.")
-            print("Audio with silent parts saved to:", output_silent_path)
-            print("Audio with non-silent parts saved to:", output_non_silent_path)
-            print("Silent parts timeline saved to:", silent_txt_path)
-            print("Non-silent parts timeline saved to:", non_silent_txt_path)
-
-        except (OSError, ValueError) as e:
-            print("An error occurred:", str(e))
-
-def main():
-    parser = argparse.ArgumentParser(description="Audio processing script")
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Detect and separate silent/non-silent audio regions")
     parser.add_argument("input_file", help="Input audio file path")
     parser.add_argument("--output_folder", default="output", help="Output folder path")
-    parser.add_argument("--min_silence_len", type=int, default=100, help="Minimum silence length (in milliseconds)")
+    parser.add_argument("--min_silence_len", type=int, default=100, help="Minimum silence length in milliseconds")
     parser.add_argument("--threshold", type=int, default=-30, help="Silence threshold in dBFS")
+    parser.add_argument("--output_format", default="mp3", help="Output audio format (default: mp3)")
+    parser.add_argument("--output_stem", default=None, help="Optional base name for generated output files")
+    return parser
 
-    args = parser.parse_args()
 
-    audio_processor = AudioProcessor(args.input_file)
-    audio_processor.process_audio(min_silence_len=args.min_silence_len, threshold=args.threshold, output_folder=args.output_folder)
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        processor = AudioProcessor(args.input_file)
+        processor.process_audio(
+            min_silence_len=args.min_silence_len,
+            threshold=args.threshold,
+            output_folder=args.output_folder,
+            output_format=args.output_format,
+            output_stem=args.output_stem,
+        )
+    except (OSError, ValueError, CouldntDecodeError, CouldntEncodeError) as exc:
+        print(f"audio-desilencer: error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,33 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
-with open('README.md', 'r', encoding='utf-8') as readme_file:
+with open("README.md", "r", encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 setup(
-    name='Audio-DeSilencer',
-    version='1.0.2',
-    description='An audio processing tool for detecting and removing silence in audio recordings.',
-    author='Boutros Tawaifi',
-    author_email='boutrous.m.tawaifi@gmail.com',
-    license='MIT',
-    url='https://github.com/BTawaifi/Audio-DeSilencer',
-    packages=find_packages(),
+    name="Audio-DeSilencer",
+    version="1.0.3",
+    description="An audio processing tool for detecting and separating silent and non-silent audio regions.",
+    author="Boutros Tawaifi",
+    author_email="boutrous.m.tawaifi@gmail.com",
+    license="MIT",
+    url="https://github.com/BTawaifi/Audio-DeSilencer",
+    packages=find_packages(exclude=("tests", "tests.*")),
+    python_requires=">=3.10",
     install_requires=[
-        'pydub',
+        "pydub>=0.25.1",
+        "audioop-lts>=0.2.2; python_version >= '3.13'",
     ],
     entry_points={
-        'console_scripts': [
-            'audio-desilencer=audio_desilencer.audio_processor:main',
+        "console_scripts": [
+            "audio-desilencer=audio_desilencer.audio_processor:main",
         ],
     },
-    keywords=['audio', 'processing', 'silence removal', 'pause removal'],
+    keywords=["audio", "processing", "silence removal", "pause removal"],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Operating System :: OS Independent",
+    ],
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
 )

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -1,226 +1,231 @@
+import ast
+import io
+import tempfile
 import unittest
-from unittest.mock import patch, MagicMock, mock_open
-import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-# Mock pydub and pydub.silence before importing AudioProcessor
-mock_pydub = MagicMock()
-mock_pydub_silence = MagicMock()
-sys.modules['pydub'] = mock_pydub
-sys.modules['pydub.silence'] = mock_pydub_silence
+from pydub import AudioSegment
+from pydub.generators import Sine
 
-from audio_desilencer.audio_processor import AudioProcessor
-
-class TestAudioProcessor(unittest.TestCase):
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    def test_split_audio_by_silence(self, mock_detect_nonsilent, mock_from_file):
-        # Configure mocks
-        mock_audio_segment = MagicMock()
-        mock_from_file.return_value = mock_audio_segment
-        mock_detect_nonsilent.return_value = [[0, 1000], [2000, 3000]]
-
-        # Instantiate AudioProcessor
-        processor = AudioProcessor("dummy.mp4a")
-
-        # Call split_audio_by_silence and assert
-        result = processor.split_audio_by_silence(min_silence_len=500, threshold=-40)
-        self.assertEqual(result, [[0, 1000], [2000, 3000]])
-        mock_from_file.assert_called_once_with("dummy.mp4a")
-        mock_detect_nonsilent.assert_called_once_with(mock_audio_segment, min_silence_len=500, silence_thresh=-40)
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    def test_is_fully_silent_when_audio_is_silent(self, mock_detect_nonsilent, mock_from_file):
-        # Configure mocks
-        mock_audio_segment = MagicMock()
-        mock_from_file.return_value = mock_audio_segment
-        mock_detect_nonsilent.return_value = []  # Simulate full silence
-
-        # Instantiate AudioProcessor
-        processor = AudioProcessor("dummy.mp4a")
-
-        # Assert is_fully_silent returns True
-        self.assertTrue(processor.is_fully_silent())
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    def test_is_fully_silent_when_audio_is_not_silent(self, mock_detect_nonsilent, mock_from_file):
-        # Configure mocks
-        mock_audio_segment = MagicMock()
-        mock_from_file.return_value = mock_audio_segment
-        mock_detect_nonsilent.return_value = [[0, 1000]]
-
-        # Instantiate AudioProcessor
-        processor = AudioProcessor("dummy.mp4a")
-
-        # Assert is_fully_silent returns False
-        self.assertFalse(processor.is_fully_silent())
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    def test_audio_processor_init_format_detection(self, mock_from_file):
-        mock_from_file.return_value = MagicMock()
-
-        AudioProcessor("dummy.mp3")
-        mock_from_file.assert_called_with("dummy.mp3")
-
-        AudioProcessor("dummy.wav")
-        mock_from_file.assert_called_with("dummy.wav")
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    def test_save_audio(self, mock_from_file):
-        mock_audio_segment = MagicMock()
-        mock_from_file.return_value = mock_audio_segment
-        processor = AudioProcessor("dummy.mp3")
-
-        audio_to_save = MagicMock()
-        processor.save_audio(audio_to_save, "output.mp3")
-
-        audio_to_save.export.assert_called_once_with("output.mp3", format="mp3")
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_save_timeline_to_text(self, mock_file, mock_from_file):
-        mock_from_file.return_value = MagicMock()
-        processor = AudioProcessor("dummy.mp3")
-
-        timeline = [(0, 1000), (2000, 3000)]
-        processor.save_timeline_to_text(timeline, "timeline.txt")
-
-        mock_file.assert_called_once_with("timeline.txt", 'w')
-        handle = mock_file()
-        handle.write.assert_any_call("[")
-        handle.write.assert_any_call("(0, 1000), ")
-        handle.write.assert_any_call("(2000, 3000), ")
-        handle.write.assert_any_call("]")
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_save_timeline_to_text_empty(self, mock_file, mock_from_file):
-        mock_from_file.return_value = MagicMock()
-        processor = AudioProcessor("dummy.mp3")
-
-        processor.save_timeline_to_text([], "empty_timeline.txt")
-
-        mock_file.assert_called_once_with("empty_timeline.txt", 'w')
-        handle = mock_file()
-        handle.write.assert_any_call("[")
-        handle.write.assert_any_call("]")
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    @patch('audio_desilencer.audio_processor.AudioSegment.empty')
-    def test_process_audio_logic(self, mock_empty, mock_detect_nonsilent, mock_from_file):
-        mock_audio = MagicMock()
-        mock_audio.__getitem__.side_effect = lambda key: MagicMock(raw_data=b'audio')
-        mock_audio._spawn.side_effect = lambda data: MagicMock(raw_data=data)
-        mock_from_file.return_value = mock_audio
-        mock_detect_nonsilent.return_value = [[100, 200], [300, 400]]
-        mock_empty.return_value = MagicMock()
-
-        processor = AudioProcessor("dummy.mp3")
-
-        with patch.object(processor, 'save_audio') as mock_save_audio, \
-             patch.object(processor, 'save_timeline_to_text') as mock_save_timeline:
-            processor.process_audio()
-
-            self.assertEqual(mock_save_audio.call_count, 2)
-            self.assertEqual(mock_save_timeline.call_count, 2)
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    @patch('audio_desilencer.audio_processor.AudioSegment.empty')
-    def test_process_audio_fully_silent(self, mock_empty, mock_detect_nonsilent, mock_from_file):
-        mock_audio = MagicMock()
-        mock_from_file.return_value = mock_audio
-        mock_detect_nonsilent.return_value = []
-        mock_empty_segment = MagicMock()
-        mock_empty.return_value = mock_empty_segment
-
-        processor = AudioProcessor("dummy.mp3")
-
-        with patch.object(processor, 'save_audio') as mock_save_audio, \
-             patch.object(processor, 'save_timeline_to_text') as mock_save_timeline:
-            processor.process_audio()
-
-            mock_detect_nonsilent.assert_called_once()
-            self.assertEqual(mock_save_audio.call_count, 2)
-            self.assertEqual(mock_save_timeline.call_count, 2)
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    @patch('audio_desilencer.audio_processor.AudioSegment.empty')
-    def test_process_audio_fully_non_silent(self, mock_empty, mock_detect_nonsilent, mock_from_file):
-        mock_audio = MagicMock()
-        mock_audio.__len__.return_value = 1000
-        mock_audio.__getitem__.side_effect = lambda key: MagicMock(raw_data=b'audio')
-        mock_audio._spawn.side_effect = lambda data: MagicMock(raw_data=data)
-        mock_from_file.return_value = mock_audio
-        mock_detect_nonsilent.return_value = [[0, 1000]]
-        mock_empty_segment = MagicMock()
-        mock_empty.return_value = mock_empty_segment
-
-        processor = AudioProcessor("dummy.mp3")
-
-        with patch.object(processor, 'save_audio') as mock_save_audio, \
-             patch.object(processor, 'save_timeline_to_text') as mock_save_timeline:
-            processor.process_audio()
-
-            mock_detect_nonsilent.assert_called_once()
-            self.assertEqual(mock_save_audio.call_count, 2)
-            self.assertEqual(mock_save_timeline.call_count, 2)
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    def test_main_defaults(self, mock_detect_nonsilent, mock_from_file):
-        mock_audio = MagicMock()
-        mock_audio._spawn.return_value = MagicMock()
-        mock_from_file.return_value = mock_audio
-        mock_detect_nonsilent.return_value = []
-
-        with patch('sys.argv', ['audio-desilencer', 'input.mp3']), \
-             patch.object(AudioProcessor, 'save_audio'), \
-             patch.object(AudioProcessor, 'save_timeline_to_text'):
-            from audio_desilencer.audio_processor import main
-            main()
-
-        mock_detect_nonsilent.assert_called_once_with(mock_audio, min_silence_len=100, silence_thresh=-30)
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    def test_main_custom_args(self, mock_detect_nonsilent, mock_from_file):
-        mock_audio = MagicMock()
-        mock_audio._spawn.return_value = MagicMock()
-        mock_from_file.return_value = mock_audio
-        mock_detect_nonsilent.return_value = []
-
-        with patch('sys.argv', [
-            'audio-desilencer', 'input.mp3',
-            '--output_folder', 'custom_output',
-            '--min_silence_len', '500',
-            '--threshold', '-40',
-        ]), patch.object(AudioProcessor, 'save_audio'), \
-             patch.object(AudioProcessor, 'save_timeline_to_text'):
-            from audio_desilencer.audio_processor import main
-            main()
-
-        mock_detect_nonsilent.assert_called_once_with(mock_audio, min_silence_len=500, silence_thresh=-40)
-
-    @patch('audio_desilencer.audio_processor.AudioSegment.from_file')
-    @patch('audio_desilencer.audio_processor.detect_nonsilent')
-    @patch('builtins.print')
-    def test_process_audio_exception(self, mock_print, mock_detect_nonsilent, mock_from_file):
-        mock_audio = MagicMock()
-        mock_from_file.return_value = mock_audio
-        mock_detect_nonsilent.side_effect = ValueError("Test Exception")
-
-        processor = AudioProcessor("dummy.mp3")
-
-        processor.process_audio()
-
-        self.assertTrue(mock_print.called)
-        self.assertTrue('An error occurred' in str(mock_print.call_args[0][0]))
+from audio_desilencer.audio_processor import (
+    AudioProcessor,
+    ProcessingResult,
+    _normalize_ranges,
+    complement_ranges,
+    main,
+)
+import audio_desilencer.audio_processor as module
 
 
-if __name__ == '__main__':
+def processor_with_audio(audio: AudioSegment, input_path: str = "recording.wav") -> AudioProcessor:
+    processor = AudioProcessor.__new__(AudioProcessor)
+    processor.input_file_path = input_path
+    processor.audio = audio
+    return processor
+
+
+class RangeTests(unittest.TestCase):
+    def test_normalize_sorts_clamps_and_merges(self):
+        self.assertEqual(
+            _normalize_ranges([(300, 500), (-20, 100), (90, 200), (800, 1200), (500, 500)], 1000),
+            [(0, 200), (300, 500), (800, 1000)],
+        )
+
+    def test_normalize_merges_touching_ranges(self):
+        self.assertEqual(_normalize_ranges([(0, 100), (100, 200), (150, 250)], 300), [(0, 250)])
+
+    def test_normalize_rejects_invalid_shape(self):
+        with self.assertRaises(ValueError):
+            _normalize_ranges([(1, 2, 3)], 10)
+
+    def test_complement_empty_ranges_is_whole_file(self):
+        self.assertEqual(complement_ranges(1000, []), [(0, 1000)])
+
+    def test_complement_full_range_is_empty(self):
+        self.assertEqual(complement_ranges(1000, [(0, 1000)]), [])
+
+    def test_complement_includes_leading_internal_and_trailing_gaps(self):
+        self.assertEqual(
+            complement_ranges(1000, [(100, 200), (400, 700)]),
+            [(0, 100), (200, 400), (700, 1000)],
+        )
+
+    def test_complement_zero_duration_is_empty(self):
+        self.assertEqual(complement_ranges(0, []), [])
+
+
+class AudioProcessorTests(unittest.TestCase):
+    @patch.object(module.AudioSegment, "from_file")
+    def test_constructor_uses_pydub_format_detection(self, from_file):
+        from_file.return_value = AudioSegment.silent(duration=10)
+        AudioProcessor("example.m4a")
+        from_file.assert_called_once_with("example.m4a")
+
+    def test_real_silence_detection_finds_tone_between_silence(self):
+        tone = Sine(440).to_audio_segment(duration=300).apply_gain(-3)
+        audio = AudioSegment.silent(duration=200) + tone + AudioSegment.silent(duration=200)
+        processor = processor_with_audio(audio)
+        ranges = processor.split_audio_by_silence(min_silence_len=100, threshold=-30)
+        self.assertEqual(len(ranges), 1)
+        start, end = ranges[0]
+        self.assertLessEqual(abs(start - 200), 10)
+        self.assertLessEqual(abs(end - 500), 10)
+
+    def test_is_fully_silent_true(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=300))
+        self.assertTrue(processor.is_fully_silent(min_silence_len=50, threshold=-30))
+
+    def test_is_fully_silent_false(self):
+        processor = processor_with_audio(Sine(440).to_audio_segment(duration=300).apply_gain(-3))
+        self.assertFalse(processor.is_fully_silent(min_silence_len=50, threshold=-30))
+
+    def test_join_ranges_preserves_requested_total_duration(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=1000, frame_rate=8000))
+        joined = processor._join_ranges([(100, 200), (400, 650)])
+        self.assertEqual(len(joined), 350)
+
+    def test_join_ranges_empty_returns_empty_audio(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=100))
+        self.assertEqual(len(processor._join_ranges([])), 0)
+
+    def test_process_includes_trailing_silence(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=1000), "meeting.wav")
+        with patch.object(processor, "split_audio_by_silence", return_value=[(200, 700)]), \
+             patch.object(processor, "save_audio") as save_audio, \
+             patch.object(processor, "save_timeline_to_text") as save_timeline, \
+             tempfile.TemporaryDirectory() as tmp:
+            result = processor.process_audio(output_folder=tmp, output_format="wav")
+
+        self.assertEqual(result.non_silent_ranges, ((200, 700),))
+        self.assertEqual(result.silent_ranges, ((0, 200), (700, 1000)))
+        self.assertEqual(len(save_audio.call_args_list[0].args[0]), 500)
+        self.assertEqual(len(save_audio.call_args_list[1].args[0]), 500)
+        self.assertEqual(save_timeline.call_args_list[0].args[0], [(0, 200), (700, 1000)])
+
+    def test_process_fully_silent_preserves_entire_audio_as_silent(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=1000), "silence.wav")
+        with patch.object(processor, "split_audio_by_silence", return_value=[]), \
+             patch.object(processor, "save_audio") as save_audio, \
+             patch.object(processor, "save_timeline_to_text"), \
+             tempfile.TemporaryDirectory() as tmp:
+            result = processor.process_audio(output_folder=tmp, output_format="wav")
+
+        self.assertEqual(result.silent_ranges, ((0, 1000),))
+        self.assertEqual(result.non_silent_ranges, ())
+        self.assertEqual(len(save_audio.call_args_list[0].args[0]), 1000)
+        self.assertEqual(len(save_audio.call_args_list[1].args[0]), 0)
+
+    def test_process_fully_non_silent_has_no_silent_output(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=1000), "speech.wav")
+        with patch.object(processor, "split_audio_by_silence", return_value=[(0, 1000)]), \
+             patch.object(processor, "save_audio") as save_audio, \
+             patch.object(processor, "save_timeline_to_text"), \
+             tempfile.TemporaryDirectory() as tmp:
+            result = processor.process_audio(output_folder=tmp, output_format="wav")
+
+        self.assertEqual(result.silent_ranges, ())
+        self.assertEqual(result.non_silent_ranges, ((0, 1000),))
+        self.assertEqual(len(save_audio.call_args_list[0].args[0]), 0)
+        self.assertEqual(len(save_audio.call_args_list[1].args[0]), 1000)
+
+    def test_process_uses_input_stem_and_requested_format(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=50), "/tmp/client-call.m4a")
+        with patch.object(processor, "split_audio_by_silence", return_value=[]), \
+             patch.object(processor, "save_audio") as save_audio, \
+             patch.object(processor, "save_timeline_to_text"), \
+             tempfile.TemporaryDirectory() as tmp:
+            result = processor.process_audio(output_folder=tmp, output_format="WAV")
+
+        self.assertTrue(result.silent_audio_path.endswith("client-call_silent.wav"))
+        self.assertTrue(result.non_silent_audio_path.endswith("client-call_non_silent.wav"))
+        self.assertEqual(save_audio.call_args_list[0].args[2], "wav")
+
+    def test_process_custom_stem_cannot_escape_output_directory(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=50), "input.wav")
+        with patch.object(processor, "split_audio_by_silence", return_value=[]), \
+             patch.object(processor, "save_audio"), \
+             patch.object(processor, "save_timeline_to_text"), \
+             tempfile.TemporaryDirectory() as tmp:
+            result = processor.process_audio(output_folder=tmp, output_format="wav", output_stem="../../safe")
+        self.assertEqual(Path(result.silent_audio_path).parent, Path(tmp))
+        self.assertEqual(Path(result.silent_audio_path).name, "safe_silent.wav")
+
+    def test_process_rejects_non_positive_min_silence(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=50))
+        with self.assertRaises(ValueError):
+            processor.process_audio(min_silence_len=0)
+
+    def test_process_rejects_unsafe_output_format(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=50))
+        with self.assertRaises(ValueError):
+            processor.process_audio(output_format="../mp3")
+
+    def test_process_returns_structured_result(self):
+        processor = processor_with_audio(AudioSegment.silent(duration=100), "clip.wav")
+        with patch.object(processor, "split_audio_by_silence", return_value=[(20, 80)]), \
+             patch.object(processor, "save_audio"), \
+             patch.object(processor, "save_timeline_to_text"), \
+             tempfile.TemporaryDirectory() as tmp:
+            result = processor.process_audio(output_folder=tmp, output_format="wav")
+        self.assertIsInstance(result, ProcessingResult)
+        self.assertEqual(result.silent_ranges, ((0, 20), (80, 100)))
+
+    def test_save_timeline_writes_valid_python_literal_without_trailing_comma(self):
+        processor = processor_with_audio(AudioSegment.empty())
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "timeline.txt"
+            processor.save_timeline_to_text([(0, 100), (200, 300)], str(path))
+            content = path.read_text(encoding="utf-8")
+        self.assertEqual(ast.literal_eval(content), [(0, 100), (200, 300)])
+        self.assertNotIn(", ]", content)
+
+    def test_save_audio_uses_requested_format(self):
+        processor = processor_with_audio(AudioSegment.empty())
+        audio = MagicMock()
+        processor.save_audio(audio, "out.wav", "wav")
+        audio.export.assert_called_once_with("out.wav", format="wav")
+
+
+class CliTests(unittest.TestCase):
+    @patch.object(module, "AudioProcessor")
+    def test_main_passes_all_options_and_returns_zero(self, processor_cls):
+        processor = processor_cls.return_value
+        code = main([
+            "input.wav",
+            "--output_folder", "out",
+            "--min_silence_len", "250",
+            "--threshold", "-42",
+            "--output_format", "wav",
+            "--output_stem", "cleaned",
+        ])
+        self.assertEqual(code, 0)
+        processor_cls.assert_called_once_with("input.wav")
+        processor.process_audio.assert_called_once_with(
+            min_silence_len=250,
+            threshold=-42,
+            output_folder="out",
+            output_format="wav",
+            output_stem="cleaned",
+        )
+
+    @patch.object(module, "AudioProcessor", side_effect=OSError("missing input"))
+    def test_main_returns_nonzero_when_loading_fails(self, _processor_cls):
+        stderr = io.StringIO()
+        with patch("sys.stderr", stderr):
+            code = main(["missing.wav"])
+        self.assertEqual(code, 1)
+        self.assertIn("missing input", stderr.getvalue())
+
+    @patch.object(module, "AudioProcessor")
+    def test_main_returns_nonzero_when_processing_fails(self, processor_cls):
+        processor_cls.return_value.process_audio.side_effect = ValueError("bad threshold")
+        stderr = io.StringIO()
+        with patch("sys.stderr", stderr):
+            code = main(["input.wav"])
+        self.assertEqual(code, 1)
+        self.assertIn("bad threshold", stderr.getvalue())
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- compute silent ranges as the full complement of normalized non-silent ranges
- preserve trailing silence and fully silent files
- return a structured processing result and let Python callers receive failures
- make CLI failures return non-zero status
- derive collision-resistant output names from the input and support configurable output formats/stems
- modernize package build metadata, Python support declaration, and package exports
- exclude tests from built distributions
- replace mock-only coverage with 26 regression tests including real pydub tone/silence detection
- expand CI across Python 3.10–3.13 and verify built wheel contents/API/CLI

This PR is intentionally broad because it closes the correctness and verification gaps found in a full code review.