### PR TITLE
fix: make silence removal non-destructive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Verify FFmpeg
+      - name: Install FFmpeg
         run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
           ffmpeg -version
           ffprobe -version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Verify FFmpeg
+        run: |
+          ffmpeg -version
+          ffprobe -version
+
       - name: Install package
         run: |
           python -m pip install --upgrade pip
@@ -69,5 +74,5 @@ jobs:
 
       - name: Verify installed API and CLI
         run: |
-          python -c "from audio_desilencer import AudioProcessor, ProcessingResult, complement_ranges; assert complement_ranges(10, [(2, 8)]) == [(0, 2), (8, 10)]"
+          python -c "from audio_desilencer import AudioProcessor, ProcessingResult, build_removal_ranges, complement_ranges; assert build_removal_ranges(1000, [(100, 900)], 200) == [(200, 800)]; assert complement_ranges(10, [(2, 8)]) == [(0, 2), (8, 10)]"
           audio-desilencer --help

--- a/README.md
+++ b/README.md
@@ -1,101 +1,148 @@
 # Audio DeSilencer
 
-Audio DeSilencer is a small Python package and CLI for detecting silent/non-silent regions, separating those regions into output audio files, and exporting the corresponding timelines.
+Audio DeSilencer is a small Python package and CLI for shortening long silent pauses **without processing the audio you keep**.
+
+The core invariant is simple:
+
+> If a source interval is retained, Audio DeSilencer does not normalize, limit, EQ, compress, de-ess, crossfade, or otherwise modify it. Only selected time ranges are removed.
 
 ```bash
 pip install audio-desilencer
 ```
 
-## Features
+## Why this design
 
-- Detect non-silent ranges with configurable dBFS and minimum-silence thresholds
-- Correctly derive the complete silent complement, including leading and trailing silence
-- Handle fully silent and fully non-silent files without dropping audio
-- Export separate silent and non-silent audio files
-- Export the exact silent/non-silent millisecond timelines
-- Choose the output codec/extension instead of forcing every result to MP3
-- Use either the Python API or the `audio-desilencer` CLI
-- Return a structured `ProcessingResult` to Python callers
+Silence removal is an editing problem, not a mastering problem. The processor therefore treats the source recording as authoritative:
 
-Codec support is provided by pydub/FFmpeg. Formats that require FFmpeg still depend on FFmpeg being installed and available on the host system.
+```text
+source audio
+    │
+    ├── detect confirmed long silence
+    │
+    ├── keep a small natural pause around speech
+    │
+    ├── remove only the middle of each accepted silence
+    │
+    └── concatenate the untouched retained source spans
+```
 
-## Silence model
+The processing backend is FFmpeg end-to-end. Audio is not first converted through pydub's integer `AudioSegment` representation, which avoids hard-clipping over-range floating-point samples from formats such as Opus before editing begins.
 
-Silence detection is controlled by:
+## Requirements
 
-- `threshold`: audio below this dBFS level is considered silent
-- `min_silence_len`: minimum duration in milliseconds before a region counts as silence
+- Python 3.10+
+- `ffmpeg` and `ffprobe` available on `PATH`
 
-The processor first obtains non-silent ranges and then computes their complement across the full audio duration. That means leading, internal, and trailing silence are represented consistently.
+No third-party Python runtime packages are required.
+
+## Defaults
+
+The defaults are intentionally conservative for speech:
+
+```text
+minimum continuous silence: 700 ms
+silence threshold:           -38 dBFS
+silence retained per pause:   150 ms
+output format:                WAV
+```
+
+A 1.5-second pause, for example, is shortened to roughly 150 ms. Speech on either side remains untouched.
 
 ## CLI
 
 ```bash
-audio-desilencer input_audio.mp3 \
+audio-desilencer input.ogg \
   --output_folder output \
-  --min_silence_len 100 \
-  --threshold -30 \
-  --output_format mp3
+  --min_silence_len 700 \
+  --threshold -38 \
+  --target_silence_len 150 \
+  --output_format wav
 ```
+
+Use `--target_silence_len 0` to remove accepted silence completely. Keeping a small value is usually more natural for speech because edits remain inside quiet material instead of landing directly on word boundaries.
 
 Optional custom output stem:
 
 ```bash
-audio-desilencer interview.m4a --output_stem cleaned --output_format wav
+audio-desilencer interview.m4a --output_stem cleaned
 ```
 
-For an input named `interview.m4a`, the default output names are:
+For `interview.m4a`, the default WAV outputs are:
 
 ```text
-interview_silent.mp3
-interview_non_silent.mp3
+interview_silent.wav
+interview_non_silent.wav
 interview_silent_parts.txt
 interview_non_silent_parts.txt
 ```
 
-The CLI returns a non-zero exit status when loading or processing fails instead of printing an error and appearing successful.
+`*_non_silent` is the desilenced recording. It still contains the small amount of pause requested by `target_silence_len`.
+
+`*_silent` contains only the material actually removed from the source, not every low-energy sample detected near speech boundaries.
 
 ## Python API
 
 ```python
 from audio_desilencer import AudioProcessor
 
-processor = AudioProcessor("input.m4a")
+processor = AudioProcessor("input.ogg")
 result = processor.process_audio(
-    min_silence_len=200,
-    threshold=-40,
+    min_silence_len=700,
+    threshold=-38,
+    target_silence_len=150,
     output_folder="output",
     output_format="wav",
 )
 
-print(result.silent_ranges)
-print(result.non_silent_ranges)
+print(result.detected_silence_ranges)
+print(result.silent_ranges)       # ranges actually removed
+print(result.non_silent_ranges)   # source ranges retained in the output
 print(result.non_silent_audio_path)
 ```
 
-You can also use the detection layer directly:
+The legacy detection method remains available:
 
 ```python
-segments = processor.split_audio_by_silence(
-    min_silence_len=200,
-    threshold=-40,
+non_silent_source_ranges = processor.split_audio_by_silence(
+    min_silence_len=700,
+    threshold=-38,
 )
-
-if processor.is_fully_silent():
-    print("No non-silent audio detected")
 ```
 
-`process_audio()` raises processing errors to Python callers. Friendly error reporting is kept at the CLI boundary so library code can reliably distinguish success from failure.
+For direct silence inspection:
 
-## Timeline format
+```python
+silent_ranges = processor.detect_silence_ranges(
+    min_silence_len=700,
+    threshold=-38,
+)
+```
 
-Timeline files contain a Python-literal list of `(start_ms, end_ms)` tuples:
+## Timeline semantics
+
+Timeline files contain Python-literal `(start_ms, end_ms)` tuples in **source time**.
 
 ```text
-[(0, 1200), (3400, 5100)]
+[(9824, 10599), (19576, 20330)]
 ```
 
-Ranges are clamped, sorted, merged when necessary, and never include zero-length intervals.
+- `silent_parts.txt` contains ranges actually removed.
+- `non_silent_parts.txt` contains source ranges retained in the desilenced output.
+- `ProcessingResult.detected_silence_ranges` exposes the full silence regions detected before pause shortening.
+
+## Signal preservation
+
+Audio DeSilencer deliberately performs no gain or tone processing.
+
+The FFmpeg render graph only uses timing operations:
+
+```text
+atrim -> timestamp reset -> concat
+```
+
+For WAV output, the package writes 32-bit floating-point PCM. This preserves over-range floating-point source samples instead of forcing them through an integer PCM ceiling. No attenuation or normalization is applied.
+
+Lossy formats such as MP3 must be re-encoded and therefore cannot be sample-identical to the source. Use WAV when validating editing quality or when you want a lossless intermediate.
 
 ## Architecture
 
@@ -104,60 +151,45 @@ CLI / Python caller
         │
         ▼
 AudioProcessor
-├── load through pydub
-├── detect non-silent ranges
-├── normalize ranges
-├── compute silent complement over full duration
-├── concatenate selected source slices
-├── export audio
-└── write timing metadata
-        │
-        ▼
-FFmpeg-backed codec support where required
+├── ffprobe source metadata
+├── FFmpeg continuous-silence detection
+├── normalize detected ranges
+├── build removal ranges from the middle of silence
+├── compute retained source ranges
+├── FFmpeg trim + concatenate retained spans
+├── export removed spans separately
+└── write source-time timelines
 ```
 
-The processing layer is shared by the CLI and Python API. Output naming is derived from the input stem by default, so processing multiple files into the same output folder does not overwrite a generic `interview_*` filename.
+This avoids the previous architecture of extracting independent speech chunks and blindly joining their raw PCM bytes at detector boundaries.
 
 ## Testing
 
-The regression suite contains both pure interval tests and tests that use real pydub `AudioSegment` data. It specifically covers:
+```bash
+python -m unittest discover -s tests -v
+```
+
+The regression suite covers:
 
 - leading, internal, and trailing silence
-- fully silent audio
-- fully non-silent audio
-- range clamping/sorting/merging
-- real tone-vs-silence detection
-- output naming and codec selection
+- fully silent and fully non-silent files
+- conservative middle-of-pause removal
+- source/removed/retained range semantics
+- real FFmpeg silence detection on synthetic audio
+- over-range float WAV preservation
+- byte-for-byte equality of retained decoded PCM on lossless fixtures
+- output naming and path containment
 - timeline serialization
-- CLI success/failure exit behavior
-- package API behavior
+- CLI success/failure behavior
 
-Run locally:
-
-```bash
-python -m unittest discover -s tests -v
-```
-
-GitHub Actions runs the suite on Python 3.10, 3.11, 3.12, and 3.13. A separate packaging job builds the wheel/source distribution, installs the wheel, verifies imports, and exercises the installed CLI.
-
-## Development
-
-```bash
-git clone https://github.com/BTawaifi/Audio-DeSilencer.git
-cd Audio-DeSilencer
-python -m pip install -e .
-python -m unittest discover -s tests -v
-```
-
-The package declares Python 3.10+ support and excludes the repository's `tests` package from built distributions.
+GitHub Actions runs the suite on Python 3.10, 3.11, 3.12, and 3.13 and separately builds and installs the wheel/source distribution.
 
 ## Scope / limitations
 
-- Threshold-based silence detection is deterministic and explainable but not semantic voice-activity detection.
-- Results still depend on choosing a threshold appropriate for the recording.
-- File-based processing keeps decoded audio in memory; it is not a streaming engine.
-- Codec availability depends on the local pydub/FFmpeg environment.
-- The optimized concatenation path joins raw slices from the same source audio and therefore assumes matching audio parameters, which is true for slices produced by this processor.
+- Detection is threshold-based, deterministic, and explainable; it is not semantic voice-activity detection.
+- Thresholds still need to match the recording environment. Quiet speech below the selected threshold can still be classified as silence, so conservative settings are recommended.
+- The current production path does not normalize loudness or repair already-clipped source audio by design.
+- FFmpeg codec support depends on the FFmpeg build installed on the host.
 
 ## License
 

--- a/audio_desilencer/__init__.py
+++ b/audio_desilencer/__init__.py
@@ -1,3 +1,13 @@
-from .audio_processor import AudioProcessor, ProcessingResult, complement_ranges
+from .audio_processor import (
+    AudioProcessor,
+    ProcessingResult,
+    build_removal_ranges,
+    complement_ranges,
+)
 
-__all__ = ["AudioProcessor", "ProcessingResult", "complement_ranges"]
+__all__ = [
+    "AudioProcessor",
+    "ProcessingResult",
+    "build_removal_ranges",
+    "complement_ranges",
+]

--- a/audio_desilencer/audio_processor.py
+++ b/audio_desilencer/audio_processor.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import json
+import math
 import os
 import re
+import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Sequence
-
-from pydub import AudioSegment
-from pydub.exceptions import CouldntDecodeError, CouldntEncodeError
-from pydub.silence import detect_nonsilent
 
 
 Timeline = list[tuple[int, int]]
@@ -24,6 +24,15 @@ class ProcessingResult:
     non_silent_timeline_path: str
     silent_ranges: tuple[tuple[int, int], ...]
     non_silent_ranges: tuple[tuple[int, int], ...]
+    detected_silence_ranges: tuple[tuple[int, int], ...] = ()
+
+
+@dataclass(frozen=True)
+class _AudioInfo:
+    duration_ms: int
+    sample_rate: int
+    channels: int
+    channel_layout: str | None
 
 
 def _normalize_ranges(ranges: Iterable[Sequence[int]], total_duration: int) -> Timeline:
@@ -68,22 +77,165 @@ def complement_ranges(total_duration: int, ranges: Iterable[Sequence[int]]) -> T
     return complement
 
 
+def build_removal_ranges(
+    total_duration: int,
+    detected_silence_ranges: Iterable[Sequence[int]],
+    target_silence_len: int,
+) -> Timeline:
+    """Return only the middle portions of confirmed silence that are safe to delete.
+
+    Internal pauses are shortened to ``target_silence_len`` total, split across both
+    sides of the cut so speech retains its natural low-level lead-in and tail. Leading
+    and trailing silence retain half that amount next to speech. A completely silent
+    file is removed in full from the non-silent output.
+    """
+    total = max(0, int(total_duration))
+    target = int(target_silence_len)
+    if target < 0:
+        raise ValueError("target_silence_len must be zero or greater")
+
+    detected = _normalize_ranges(detected_silence_ranges, total)
+    removals: Timeline = []
+    left_keep = target // 2
+    right_keep = target - left_keep
+
+    for start, end in detected:
+        duration = end - start
+        if duration <= target:
+            continue
+
+        if start == 0 and end == total:
+            cut_start, cut_end = 0, total
+        elif start == 0:
+            cut_start, cut_end = 0, end - right_keep
+        elif end == total:
+            cut_start, cut_end = start + left_keep, total
+        else:
+            cut_start, cut_end = start + left_keep, end - right_keep
+
+        if cut_end > cut_start:
+            removals.append((cut_start, cut_end))
+
+    return _normalize_ranges(removals, total)
+
+
 class AudioProcessor:
+    """Non-destructive silence editor backed directly by FFmpeg.
+
+    The processor never normalizes, limits, filters, crossfades, or otherwise changes
+    retained audio. It detects sufficiently long silence, removes only the middle of
+    those pauses, and asks FFmpeg to concatenate the untouched retained source spans.
+    """
+
     def __init__(self, input_file_path: str | os.PathLike[str]):
         self.input_file_path = os.fspath(input_file_path)
-        self.audio = AudioSegment.from_file(self.input_file_path)
+        if not Path(self.input_file_path).is_file():
+            raise OSError(f"Input file does not exist: {self.input_file_path}")
+        self._require_ffmpeg()
+        self._info = self._probe_audio()
 
-    def split_audio_by_silence(self, min_silence_len: int, threshold: int) -> Timeline:
-        ranges = detect_nonsilent(
-            self.audio,
-            min_silence_len=min_silence_len,
-            silence_thresh=threshold,
+    @staticmethod
+    def _require_ffmpeg() -> None:
+        missing = [name for name in ("ffmpeg", "ffprobe") if shutil.which(name) is None]
+        if missing:
+            raise OSError(f"Required executable(s) not found on PATH: {', '.join(missing)}")
+
+    @staticmethod
+    def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or str(exc)).strip()
+            raise OSError(detail or "FFmpeg command failed") from exc
+
+    def _probe_audio(self) -> _AudioInfo:
+        result = self._run([
+            "ffprobe",
+            "-v", "error",
+            "-select_streams", "a:0",
+            "-show_entries", "stream=sample_rate,channels,channel_layout:format=duration",
+            "-of", "json",
+            self.input_file_path,
+        ])
+        try:
+            payload = json.loads(result.stdout)
+            stream = payload["streams"][0]
+            duration_s = float(payload["format"]["duration"])
+            sample_rate = int(stream["sample_rate"])
+            channels = int(stream["channels"])
+            channel_layout = stream.get("channel_layout") or None
+        except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise OSError("Could not read audio stream metadata") from exc
+
+        if not math.isfinite(duration_s) or duration_s < 0:
+            raise OSError("Audio duration is invalid")
+        return _AudioInfo(
+            duration_ms=max(0, int(round(duration_s * 1000))),
+            sample_rate=sample_rate,
+            channels=channels,
+            channel_layout=channel_layout,
         )
-        return [(int(start), int(end)) for start, end in ranges]
 
-    def save_audio(self, audio: AudioSegment, output_path: str, output_format: str = "mp3") -> None:
-        audio.export(output_path, format=output_format)
-        print(f"Saved audio to {output_path}")
+    def detect_silence_ranges(self, min_silence_len: int = 700, threshold: float = -38.0) -> Timeline:
+        """Detect continuous silence using FFmpeg's RMS-based silencedetect filter."""
+        if min_silence_len <= 0:
+            raise ValueError("min_silence_len must be greater than zero")
+        if not math.isfinite(float(threshold)):
+            raise ValueError("threshold must be a finite dBFS value")
+
+        duration_s = min_silence_len / 1000.0
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-nostats",
+                "-i", self.input_file_path,
+                "-af", f"silencedetect=n={float(threshold):g}dB:d={duration_s:.6f}",
+                "-f", "null",
+                "-",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "FFmpeg silence detection failed").strip()
+            raise OSError(detail)
+
+        ranges: Timeline = []
+        current_start_ms: int | None = None
+        start_re = re.compile(r"silence_start:\s*([0-9.]+)")
+        end_re = re.compile(r"silence_end:\s*([0-9.]+)")
+
+        for line in result.stderr.splitlines():
+            start_match = start_re.search(line)
+            if start_match:
+                current_start_ms = max(0, int(round(float(start_match.group(1)) * 1000)))
+                continue
+
+            end_match = end_re.search(line)
+            if end_match and current_start_ms is not None:
+                end_ms = min(self._info.duration_ms, int(round(float(end_match.group(1)) * 1000)))
+                if end_ms > current_start_ms:
+                    ranges.append((current_start_ms, end_ms))
+                current_start_ms = None
+
+        if current_start_ms is not None and current_start_ms < self._info.duration_ms:
+            ranges.append((current_start_ms, self._info.duration_ms))
+
+        return _normalize_ranges(ranges, self._info.duration_ms)
+
+    def split_audio_by_silence(self, min_silence_len: int, threshold: float) -> Timeline:
+        """Backward-compatible detection API returning non-silent source ranges."""
+        silent = self.detect_silence_ranges(min_silence_len=min_silence_len, threshold=threshold)
+        return complement_ranges(self._info.duration_ms, silent)
+
+    def is_fully_silent(self, min_silence_len: int = 700, threshold: float = -38.0) -> bool:
+        return not self.split_audio_by_silence(min_silence_len, threshold)
 
     def save_timeline_to_text(self, timeline_data: Iterable[Sequence[int]], output_path: str) -> None:
         timeline = [(int(start), int(end)) for start, end in timeline_data]
@@ -91,39 +243,82 @@ class AudioProcessor:
             file.write(repr(timeline))
         print(f"Saved timeline data to {output_path}")
 
-    def is_fully_silent(self, min_silence_len: int = 100, threshold: int = -30) -> bool:
-        return not self.split_audio_by_silence(min_silence_len, threshold)
+    def _render_ranges(self, ranges: Iterable[Sequence[int]], output_path: Path, output_format: str) -> None:
+        normalized = _normalize_ranges(ranges, self._info.duration_ms)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    def _join_ranges(self, ranges: Iterable[Sequence[int]]) -> AudioSegment:
-        segments = [self.audio[int(start):int(end)] for start, end in ranges if int(end) > int(start)]
-        if not segments:
-            return AudioSegment.empty()
-        return self.audio._spawn(b"".join(segment.raw_data for segment in segments))
+        if not normalized:
+            layout = self._info.channel_layout
+            if not layout:
+                layout = "mono" if self._info.channels == 1 else "stereo"
+            command = [
+                "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+                "-f", "lavfi",
+                "-i", f"anullsrc=r={self._info.sample_rate}:cl={layout}",
+                "-t", "0.001",
+            ]
+            if output_format == "wav":
+                command += ["-c:a", "pcm_f32le"]
+            command.append(str(output_path))
+            self._run(command)
+            return
+
+        filters: list[str] = []
+        labels: list[str] = []
+        for index, (start, end) in enumerate(normalized):
+            label = f"a{index}"
+            filters.append(
+                f"[0:a:0]atrim=start={start / 1000:.6f}:end={end / 1000:.6f},"
+                f"asetpts=PTS-STARTPTS[{label}]"
+            )
+            labels.append(f"[{label}]")
+
+        if len(normalized) == 1:
+            filter_complex = filters[0]
+            output_label = labels[0]
+        else:
+            output_label = "[outa]"
+            filter_complex = ";".join(filters) + ";" + "".join(labels) + f"concat=n={len(labels)}:v=0:a=1{output_label}"
+
+        command = [
+            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+            "-i", self.input_file_path,
+            "-filter_complex", filter_complex,
+            "-map", output_label,
+        ]
+        if output_format == "wav":
+            command += ["-c:a", "pcm_f32le"]
+        command.append(str(output_path))
+        self._run(command)
 
     def process_audio(
         self,
-        min_silence_len: int = 100,
-        threshold: int = -30,
+        min_silence_len: int = 700,
+        threshold: float = -38.0,
+        target_silence_len: int = 150,
         output_folder: str | os.PathLike[str] = "output",
-        output_format: str = "mp3",
+        output_format: str = "wav",
         output_stem: str | None = None,
     ) -> ProcessingResult:
         if min_silence_len <= 0:
             raise ValueError("min_silence_len must be greater than zero")
+        if target_silence_len < 0:
+            raise ValueError("target_silence_len must be zero or greater")
+        if not math.isfinite(float(threshold)):
+            raise ValueError("threshold must be a finite dBFS value")
+
         normalized_format = output_format.strip().lower()
         if not re.fullmatch(r"[a-z0-9]+", normalized_format):
             raise ValueError("output_format must be a simple format name such as 'mp3' or 'wav'")
 
         print("Processing audio...")
-        duration = len(self.audio)
-        non_silent_ranges = _normalize_ranges(
-            self.split_audio_by_silence(min_silence_len, threshold),
-            duration,
+        detected_silence_ranges = self.detect_silence_ranges(min_silence_len, threshold)
+        removed_ranges = build_removal_ranges(
+            self._info.duration_ms,
+            detected_silence_ranges,
+            target_silence_len,
         )
-        silent_ranges = complement_ranges(duration, non_silent_ranges)
-
-        audio_silent = self._join_ranges(silent_ranges)
-        audio_non_silent = self._join_ranges(non_silent_ranges)
+        retained_ranges = complement_ranges(self._info.duration_ms, removed_ranges)
 
         output_directory = Path(output_folder)
         output_directory.mkdir(parents=True, exist_ok=True)
@@ -137,10 +332,10 @@ class AudioProcessor:
         silent_timeline_path = output_directory / f"{safe_stem}_silent_parts.txt"
         non_silent_timeline_path = output_directory / f"{safe_stem}_non_silent_parts.txt"
 
-        self.save_audio(audio_silent, str(silent_audio_path), normalized_format)
-        self.save_audio(audio_non_silent, str(non_silent_audio_path), normalized_format)
-        self.save_timeline_to_text(silent_ranges, str(silent_timeline_path))
-        self.save_timeline_to_text(non_silent_ranges, str(non_silent_timeline_path))
+        self._render_ranges(removed_ranges, silent_audio_path, normalized_format)
+        self._render_ranges(retained_ranges, non_silent_audio_path, normalized_format)
+        self.save_timeline_to_text(removed_ranges, str(silent_timeline_path))
+        self.save_timeline_to_text(retained_ranges, str(non_silent_timeline_path))
 
         print("Audio processing completed.")
         return ProcessingResult(
@@ -148,18 +343,25 @@ class AudioProcessor:
             non_silent_audio_path=str(non_silent_audio_path),
             silent_timeline_path=str(silent_timeline_path),
             non_silent_timeline_path=str(non_silent_timeline_path),
-            silent_ranges=tuple(silent_ranges),
-            non_silent_ranges=tuple(non_silent_ranges),
+            silent_ranges=tuple(removed_ranges),
+            non_silent_ranges=tuple(retained_ranges),
+            detected_silence_ranges=tuple(detected_silence_ranges),
         )
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Detect and separate silent/non-silent audio regions")
+    parser = argparse.ArgumentParser(description="Remove long silence without processing retained audio")
     parser.add_argument("input_file", help="Input audio file path")
     parser.add_argument("--output_folder", default="output", help="Output folder path")
-    parser.add_argument("--min_silence_len", type=int, default=100, help="Minimum silence length in milliseconds")
-    parser.add_argument("--threshold", type=int, default=-30, help="Silence threshold in dBFS")
-    parser.add_argument("--output_format", default="mp3", help="Output audio format (default: mp3)")
+    parser.add_argument("--min_silence_len", type=int, default=700, help="Minimum continuous silence in milliseconds")
+    parser.add_argument("--threshold", type=float, default=-38.0, help="Silence threshold in dBFS")
+    parser.add_argument(
+        "--target_silence_len",
+        type=int,
+        default=150,
+        help="Silence to keep for each internal pause in milliseconds",
+    )
+    parser.add_argument("--output_format", default="wav", help="Output audio format (default: wav)")
     parser.add_argument("--output_stem", default=None, help="Optional base name for generated output files")
     return parser
 
@@ -173,11 +375,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         processor.process_audio(
             min_silence_len=args.min_silence_len,
             threshold=args.threshold,
+            target_silence_len=args.target_silence_len,
             output_folder=args.output_folder,
             output_format=args.output_format,
             output_stem=args.output_stem,
         )
-    except (OSError, ValueError, CouldntDecodeError, CouldntEncodeError) as exc:
+    except (OSError, ValueError) as exc:
         print(f"audio-desilencer: error: {exc}", file=sys.stderr)
         return 1
     return 0

--- a/setup.py
+++ b/setup.py
@@ -6,23 +6,20 @@ with open("README.md", "r", encoding="utf-8") as readme_file:
 setup(
     name="Audio-DeSilencer",
     version="1.0.3",
-    description="An audio processing tool for detecting and separating silent and non-silent audio regions.",
+    description="A non-destructive FFmpeg-backed silence remover for speech and general audio.",
     author="Boutros Tawaifi",
     author_email="boutrous.m.tawaifi@gmail.com",
     license="MIT",
     url="https://github.com/BTawaifi/Audio-DeSilencer",
     packages=find_packages(exclude=("tests", "tests.*")),
     python_requires=">=3.10",
-    install_requires=[
-        "pydub>=0.25.1",
-        "audioop-lts>=0.2.2; python_version >= '3.13'",
-    ],
+    install_requires=[],
     entry_points={
         "console_scripts": [
             "audio-desilencer=audio_desilencer.audio_processor:main",
         ],
     },
-    keywords=["audio", "processing", "silence removal", "pause removal"],
+    keywords=["audio", "processing", "silence removal", "pause removal", "ffmpeg"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -1,28 +1,49 @@
 import ast
 import io
+import math
+import struct
+import subprocess
 import tempfile
 import unittest
+import wave
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-from pydub import AudioSegment
-from pydub.generators import Sine
+from unittest.mock import patch
 
 from audio_desilencer.audio_processor import (
     AudioProcessor,
     ProcessingResult,
     _normalize_ranges,
+    build_removal_ranges,
     complement_ranges,
     main,
 )
 import audio_desilencer.audio_processor as module
 
 
-def processor_with_audio(audio: AudioSegment, input_path: str = "recording.wav") -> AudioProcessor:
-    processor = AudioProcessor.__new__(AudioProcessor)
-    processor.input_file_path = input_path
-    processor.audio = audio
-    return processor
+def write_test_wav(path: Path, sections, sample_rate: int = 8000) -> None:
+    """Write mono 16-bit PCM. sections is [(duration_ms, amplitude_0_to_1, hz)]."""
+    samples = []
+    for duration_ms, amplitude, frequency in sections:
+        count = int(sample_rate * duration_ms / 1000)
+        for index in range(count):
+            if amplitude == 0:
+                value = 0
+            else:
+                value = int(32767 * amplitude * math.sin(2 * math.pi * frequency * index / sample_rate))
+            samples.append(value)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(struct.pack(f"<{len(samples)}h", *samples))
+
+
+def decode_f32(path: Path) -> bytes:
+    return subprocess.run(
+        ["ffmpeg", "-hide_banner", "-loglevel", "error", "-i", str(path), "-f", "f32le", "-acodec", "pcm_f32le", "-"],
+        check=True,
+        capture_output=True,
+    ).stdout
 
 
 class RangeTests(unittest.TestCase):
@@ -32,159 +53,167 @@ class RangeTests(unittest.TestCase):
             [(0, 200), (300, 500), (800, 1000)],
         )
 
-    def test_normalize_merges_touching_ranges(self):
-        self.assertEqual(_normalize_ranges([(0, 100), (100, 200), (150, 250)], 300), [(0, 250)])
-
-    def test_normalize_rejects_invalid_shape(self):
-        with self.assertRaises(ValueError):
-            _normalize_ranges([(1, 2, 3)], 10)
-
-    def test_complement_empty_ranges_is_whole_file(self):
-        self.assertEqual(complement_ranges(1000, []), [(0, 1000)])
-
-    def test_complement_full_range_is_empty(self):
-        self.assertEqual(complement_ranges(1000, [(0, 1000)]), [])
-
     def test_complement_includes_leading_internal_and_trailing_gaps(self):
         self.assertEqual(
             complement_ranges(1000, [(100, 200), (400, 700)]),
             [(0, 100), (200, 400), (700, 1000)],
         )
 
-    def test_complement_zero_duration_is_empty(self):
-        self.assertEqual(complement_ranges(0, []), [])
+    def test_build_removal_shortens_only_middle_of_internal_silence(self):
+        self.assertEqual(build_removal_ranges(2000, [(500, 1500)], 200), [(600, 1400)])
+
+    def test_build_removal_keeps_half_target_next_to_leading_and_trailing_speech(self):
+        self.assertEqual(
+            build_removal_ranges(2000, [(0, 500), (1500, 2000)], 200),
+            [(0, 400), (1600, 2000)],
+        )
+
+    def test_build_removal_fully_silent_file_removes_everything(self):
+        self.assertEqual(build_removal_ranges(1000, [(0, 1000)], 150), [(0, 1000)])
+
+    def test_build_removal_rejects_negative_target(self):
+        with self.assertRaises(ValueError):
+            build_removal_ranges(1000, [(0, 500)], -1)
 
 
 class AudioProcessorTests(unittest.TestCase):
-    @patch.object(module.AudioSegment, "from_file")
-    def test_constructor_uses_pydub_format_detection(self, from_file):
-        from_file.return_value = AudioSegment.silent(duration=10)
-        AudioProcessor("example.m4a")
-        from_file.assert_called_once_with("example.m4a")
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+
+    def test_constructor_rejects_missing_input(self):
+        with self.assertRaises(OSError):
+            AudioProcessor(self.root / "missing.wav")
 
     def test_real_silence_detection_finds_tone_between_silence(self):
-        tone = Sine(440).to_audio_segment(duration=300).apply_gain(-3)
-        audio = AudioSegment.silent(duration=200) + tone + AudioSegment.silent(duration=200)
-        processor = processor_with_audio(audio)
-        ranges = processor.split_audio_by_silence(min_silence_len=100, threshold=-30)
-        self.assertEqual(len(ranges), 1)
-        start, end = ranges[0]
-        self.assertLessEqual(abs(start - 200), 10)
-        self.assertLessEqual(abs(end - 500), 10)
+        source = self.root / "tone.wav"
+        write_test_wav(source, [(200, 0, 440), (300, 0.8, 440), (200, 0, 440)])
+        processor = AudioProcessor(source)
+        silent = processor.detect_silence_ranges(min_silence_len=100, threshold=-30)
+        self.assertEqual(len(silent), 2)
+        self.assertLessEqual(abs(silent[0][0] - 0), 10)
+        self.assertLessEqual(abs(silent[0][1] - 200), 10)
+        self.assertLessEqual(abs(silent[1][0] - 500), 10)
+        self.assertLessEqual(abs(silent[1][1] - 700), 10)
 
-    def test_is_fully_silent_true(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=300))
-        self.assertTrue(processor.is_fully_silent(min_silence_len=50, threshold=-30))
+        nonsilent = processor.split_audio_by_silence(min_silence_len=100, threshold=-30)
+        self.assertEqual(len(nonsilent), 1)
+        self.assertLessEqual(abs(nonsilent[0][0] - 200), 10)
+        self.assertLessEqual(abs(nonsilent[0][1] - 500), 10)
 
-    def test_is_fully_silent_false(self):
-        processor = processor_with_audio(Sine(440).to_audio_segment(duration=300).apply_gain(-3))
-        self.assertFalse(processor.is_fully_silent(min_silence_len=50, threshold=-30))
+    def test_is_fully_silent_and_non_silent(self):
+        silent_path = self.root / "silent.wav"
+        tone_path = self.root / "tone.wav"
+        write_test_wav(silent_path, [(500, 0, 440)])
+        write_test_wav(tone_path, [(500, 0.8, 440)])
+        self.assertTrue(AudioProcessor(silent_path).is_fully_silent(min_silence_len=100, threshold=-30))
+        self.assertFalse(AudioProcessor(tone_path).is_fully_silent(min_silence_len=100, threshold=-30))
 
-    def test_join_ranges_preserves_requested_total_duration(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=1000, frame_rate=8000))
-        joined = processor._join_ranges([(100, 200), (400, 650)])
-        self.assertEqual(len(joined), 350)
+    def test_process_shortens_pauses_and_reports_removed_and_retained_ranges(self):
+        source = self.root / "meeting.wav"
+        write_test_wav(source, [
+            (200, 0, 440),
+            (300, 0.8, 440),
+            (1000, 0, 440),
+            (300, 0.8, 440),
+            (200, 0, 440),
+        ])
+        processor = AudioProcessor(source)
+        result = processor.process_audio(
+            min_silence_len=100,
+            threshold=-30,
+            target_silence_len=100,
+            output_folder=self.root / "out",
+            output_format="wav",
+        )
 
-    def test_join_ranges_empty_returns_empty_audio(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=100))
-        self.assertEqual(len(processor._join_ranges([])), 0)
+        self.assertIsInstance(result, ProcessingResult)
+        self.assertEqual(result.silent_ranges, ((0, 150), (550, 1450), (1850, 2000)))
+        self.assertEqual(result.non_silent_ranges, ((150, 550), (1450, 1850)))
+        self.assertEqual(result.detected_silence_ranges, ((0, 200), (500, 1500), (1800, 2000)))
+        self.assertTrue(Path(result.non_silent_audio_path).is_file())
+        self.assertTrue(Path(result.silent_audio_path).is_file())
 
-    def test_process_includes_trailing_silence(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=1000), "meeting.wav")
-        with patch.object(processor, "split_audio_by_silence", return_value=[(200, 700)]), \
-             patch.object(processor, "save_audio") as save_audio, \
-             patch.object(processor, "save_timeline_to_text") as save_timeline, \
-             tempfile.TemporaryDirectory() as tmp:
-            result = processor.process_audio(output_folder=tmp, output_format="wav")
+    def test_retained_pcm_is_unchanged(self):
+        source = self.root / "signal.wav"
+        write_test_wav(source, [
+            (200, 0, 440),
+            (300, 0.72, 323),
+            (1000, 0, 440),
+            (300, 0.51, 517),
+            (200, 0, 440),
+        ])
+        processor = AudioProcessor(source)
+        result = processor.process_audio(
+            min_silence_len=100,
+            threshold=-30,
+            target_silence_len=100,
+            output_folder=self.root / "out2",
+            output_format="wav",
+        )
 
-        self.assertEqual(result.non_silent_ranges, ((200, 700),))
-        self.assertEqual(result.silent_ranges, ((0, 200), (700, 1000)))
-        self.assertEqual(len(save_audio.call_args_list[0].args[0]), 500)
-        self.assertEqual(len(save_audio.call_args_list[1].args[0]), 500)
-        self.assertEqual(save_timeline.call_args_list[0].args[0], [(0, 200), (700, 1000)])
+        source_f32 = decode_f32(source)
+        output_f32 = decode_f32(Path(result.non_silent_audio_path))
+        bytes_per_frame = 4
+        frames_per_ms = 8
 
-    def test_process_fully_silent_preserves_entire_audio_as_silent(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=1000), "silence.wav")
-        with patch.object(processor, "split_audio_by_silence", return_value=[]), \
-             patch.object(processor, "save_audio") as save_audio, \
-             patch.object(processor, "save_timeline_to_text"), \
-             tempfile.TemporaryDirectory() as tmp:
-            result = processor.process_audio(output_folder=tmp, output_format="wav")
+        expected = b"".join(
+            source_f32[start * frames_per_ms * bytes_per_frame:end * frames_per_ms * bytes_per_frame]
+            for start, end in result.non_silent_ranges
+        )
+        self.assertEqual(output_f32, expected)
 
-        self.assertEqual(result.silent_ranges, ((0, 1000),))
-        self.assertEqual(result.non_silent_ranges, ())
-        self.assertEqual(len(save_audio.call_args_list[0].args[0]), 1000)
-        self.assertEqual(len(save_audio.call_args_list[1].args[0]), 0)
+    def test_float_wav_render_does_not_integer_clip_over_range_samples(self):
+        raw = self.root / "over.f32"
+        source = self.root / "over.wav"
+        values = [0.0, 0.5, 1.25, -1.4, 0.25] * 1600
+        raw.write_bytes(struct.pack(f"<{len(values)}f", *values))
+        subprocess.run([
+            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+            "-f", "f32le", "-ar", "8000", "-ac", "1", "-i", str(raw),
+            "-c:a", "pcm_f32le", str(source),
+        ], check=True)
 
-    def test_process_fully_non_silent_has_no_silent_output(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=1000), "speech.wav")
-        with patch.object(processor, "split_audio_by_silence", return_value=[(0, 1000)]), \
-             patch.object(processor, "save_audio") as save_audio, \
-             patch.object(processor, "save_timeline_to_text"), \
-             tempfile.TemporaryDirectory() as tmp:
-            result = processor.process_audio(output_folder=tmp, output_format="wav")
-
-        self.assertEqual(result.silent_ranges, ())
-        self.assertEqual(result.non_silent_ranges, ((0, 1000),))
-        self.assertEqual(len(save_audio.call_args_list[0].args[0]), 0)
-        self.assertEqual(len(save_audio.call_args_list[1].args[0]), 1000)
-
-    def test_process_uses_input_stem_and_requested_format(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=50), "/tmp/client-call.m4a")
-        with patch.object(processor, "split_audio_by_silence", return_value=[]), \
-             patch.object(processor, "save_audio") as save_audio, \
-             patch.object(processor, "save_timeline_to_text"), \
-             tempfile.TemporaryDirectory() as tmp:
-            result = processor.process_audio(output_folder=tmp, output_format="WAV")
-
-        self.assertTrue(result.silent_audio_path.endswith("client-call_silent.wav"))
-        self.assertTrue(result.non_silent_audio_path.endswith("client-call_non_silent.wav"))
-        self.assertEqual(save_audio.call_args_list[0].args[2], "wav")
+        processor = AudioProcessor(source)
+        out = self.root / "rendered.wav"
+        processor._render_ranges([(0, processor._info.duration_ms)], out, "wav")
+        decoded = struct.unpack(f"<{len(values)}f", decode_f32(out))
+        self.assertGreater(max(decoded), 1.0)
+        self.assertLess(min(decoded), -1.0)
+        for actual, expected in zip(decoded[:5], values[:5]):
+            self.assertAlmostEqual(actual, expected, places=6)
 
     def test_process_custom_stem_cannot_escape_output_directory(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=50), "input.wav")
-        with patch.object(processor, "split_audio_by_silence", return_value=[]), \
-             patch.object(processor, "save_audio"), \
-             patch.object(processor, "save_timeline_to_text"), \
-             tempfile.TemporaryDirectory() as tmp:
-            result = processor.process_audio(output_folder=tmp, output_format="wav", output_stem="../../safe")
-        self.assertEqual(Path(result.silent_audio_path).parent, Path(tmp))
-        self.assertEqual(Path(result.silent_audio_path).name, "safe_silent.wav")
+        source = self.root / "input.wav"
+        write_test_wav(source, [(300, 0.8, 440)])
+        processor = AudioProcessor(source)
+        result = processor.process_audio(
+            output_folder=self.root / "safe",
+            output_format="wav",
+            output_stem="../../cleaned",
+        )
+        self.assertEqual(Path(result.non_silent_audio_path).parent, self.root / "safe")
+        self.assertEqual(Path(result.non_silent_audio_path).name, "cleaned_non_silent.wav")
 
-    def test_process_rejects_non_positive_min_silence(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=50))
+    def test_process_rejects_invalid_options(self):
+        source = self.root / "input.wav"
+        write_test_wav(source, [(300, 0.8, 440)])
+        processor = AudioProcessor(source)
         with self.assertRaises(ValueError):
             processor.process_audio(min_silence_len=0)
-
-    def test_process_rejects_unsafe_output_format(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=50))
+        with self.assertRaises(ValueError):
+            processor.process_audio(target_silence_len=-1)
         with self.assertRaises(ValueError):
             processor.process_audio(output_format="../mp3")
 
-    def test_process_returns_structured_result(self):
-        processor = processor_with_audio(AudioSegment.silent(duration=100), "clip.wav")
-        with patch.object(processor, "split_audio_by_silence", return_value=[(20, 80)]), \
-             patch.object(processor, "save_audio"), \
-             patch.object(processor, "save_timeline_to_text"), \
-             tempfile.TemporaryDirectory() as tmp:
-            result = processor.process_audio(output_folder=tmp, output_format="wav")
-        self.assertIsInstance(result, ProcessingResult)
-        self.assertEqual(result.silent_ranges, ((0, 20), (80, 100)))
-
-    def test_save_timeline_writes_valid_python_literal_without_trailing_comma(self):
-        processor = processor_with_audio(AudioSegment.empty())
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "timeline.txt"
-            processor.save_timeline_to_text([(0, 100), (200, 300)], str(path))
-            content = path.read_text(encoding="utf-8")
-        self.assertEqual(ast.literal_eval(content), [(0, 100), (200, 300)])
-        self.assertNotIn(", ]", content)
-
-    def test_save_audio_uses_requested_format(self):
-        processor = processor_with_audio(AudioSegment.empty())
-        audio = MagicMock()
-        processor.save_audio(audio, "out.wav", "wav")
-        audio.export.assert_called_once_with("out.wav", format="wav")
+    def test_save_timeline_writes_valid_python_literal(self):
+        source = self.root / "input.wav"
+        write_test_wav(source, [(100, 0.8, 440)])
+        processor = AudioProcessor(source)
+        path = self.root / "timeline.txt"
+        processor.save_timeline_to_text([(0, 100), (200, 300)], str(path))
+        self.assertEqual(ast.literal_eval(path.read_text(encoding="utf-8")), [(0, 100), (200, 300)])
 
 
 class CliTests(unittest.TestCase):
@@ -194,16 +223,18 @@ class CliTests(unittest.TestCase):
         code = main([
             "input.wav",
             "--output_folder", "out",
-            "--min_silence_len", "250",
-            "--threshold", "-42",
+            "--min_silence_len", "700",
+            "--threshold", "-38",
+            "--target_silence_len", "120",
             "--output_format", "wav",
             "--output_stem", "cleaned",
         ])
         self.assertEqual(code, 0)
         processor_cls.assert_called_once_with("input.wav")
         processor.process_audio.assert_called_once_with(
-            min_silence_len=250,
-            threshold=-42,
+            min_silence_len=700,
+            threshold=-38.0,
+            target_silence_len=120,
             output_folder="out",
             output_format="wav",
             output_stem="cleaned",


### PR DESCRIPTION
## Summary
- replace pydub processing path with FFmpeg end-to-end detection/rendering
- shorten only the middle of confirmed long silence instead of rebuilding speech chunks
- preserve retained decoded PCM exactly on lossless output
- write float WAV output to avoid integer hard-clipping of over-range Opus samples
- add `--target_silence_len` and safer speech-oriented defaults (`700 ms`, `-38 dBFS`, `150 ms` retained pause)
- make `_silent` contain only material actually removed
- remove unused pydub/audioop runtime dependencies
- document the signal-preservation invariant and timeline semantics

## Validation
- local regression suite: 18/18 passing
- retained PCM regression verifies byte-for-byte equality on lossless fixtures
- over-range float regression verifies samples above ±1.0 are not integer-clipped
- tested against the supplied WhatsApp Opus recording: retained float PCM is byte-for-byte identical to the source decode; only selected silence spans are removed
