### PR TITLE
release: prepare deterministic 1.1.0 silence detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable user-facing changes to Audio DeSilencer are documented here.
+
+## 1.1.0
+
+### Changed
+
+- Replaced speech-chunk reconstruction with a non-destructive FFmpeg edit-list renderer.
+- Silence removal now shortens only the middle of accepted pauses and preserves a configurable amount of natural pause.
+- WAV output uses 32-bit floating-point PCM so over-range decoded samples are not forced through an integer PCM ceiling.
+- Defaults are now speech-oriented: 700 ms minimum silence, -38 dBFS threshold, 150 ms retained pause, WAV output.
+- `silent_ranges` / `*_silent_parts.txt` now mean ranges actually removed from the source.
+- `*_silent.wav` is explicitly an inspection artifact made from removed source ranges.
+- Removed pydub/audioop runtime dependencies; FFmpeg and FFprobe are explicit external requirements.
+
+### Added
+
+- `--target_silence_len`.
+- Deterministic `--threshold auto` mode with conservative peak-window analysis.
+- Optional `--hysteresis_db` for stable threshold transitions; auto mode defaults to 3 dB.
+- `ProcessingResult.resolved_threshold_dbfs` and `ProcessingResult.detector`.
+- Conservative stereo/multichannel behavior: activity on any channel protects the interval.
+- Automatic FFmpeg filter-script fallback for recordings with very large edit graphs.
+- Regression coverage for retained-sample identity, float over-range preservation, adaptive thresholding, hysteresis, multichannel safety, and large edit lists.
+- FFmpeg installation and tuning guidance in the README.
+
+### Compatibility
+
+- Numeric thresholds without hysteresis keep the stable FFmpeg `silencedetect` path.
+- `split_audio_by_silence()` remains available for callers that need non-silent source ranges.
+
+## 1.0.3
+
+- Hardened range normalization, timeline handling, packaging, CLI error behavior, and Python 3.13 compatibility.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,37 @@ The core invariant is simple:
 pip install audio-desilencer
 ```
 
+## Requirements
+
+- Python 3.10+
+- `ffmpeg` and `ffprobe` available on `PATH`
+
+No third-party Python runtime packages are required.
+
+Install FFmpeg separately if needed:
+
+```text
+Windows:
+winget install Gyan.FFmpeg
+
+macOS:
+brew install ffmpeg
+
+Ubuntu / Debian:
+sudo apt update
+sudo apt install ffmpeg
+```
+
+Verify:
+
+```bash
+ffmpeg -version
+ffprobe -version
+```
+
 ## Why this design
 
-Silence removal is an editing problem, not a mastering problem. The processor therefore treats the source recording as authoritative:
+Silence removal is an editing problem, not a mastering problem. The source recording stays authoritative:
 
 ```text
 source audio
@@ -26,18 +54,11 @@ source audio
     └── concatenate the untouched retained source spans
 ```
 
-The processing backend is FFmpeg end-to-end. Audio is not first converted through pydub's integer `AudioSegment` representation, which avoids hard-clipping over-range floating-point samples from formats such as Opus before editing begins.
-
-## Requirements
-
-- Python 3.10+
-- `ffmpeg` and `ffprobe` available on `PATH`
-
-No third-party Python runtime packages are required.
+The processing backend is FFmpeg end-to-end. Audio is not first converted through an integer `AudioSegment` representation, avoiding premature integer clipping of over-range floating-point samples from formats such as Opus.
 
 ## Defaults
 
-The defaults are intentionally conservative for speech:
+The stable defaults are intentionally conservative for speech:
 
 ```text
 minimum continuous silence: 700 ms
@@ -47,6 +68,39 @@ output format:                WAV
 ```
 
 A 1.5-second pause, for example, is shortened to roughly 150 ms. Speech on either side remains untouched.
+
+## Detection modes
+
+### Fixed threshold — default
+
+```bash
+audio-desilencer input.ogg --threshold -38
+```
+
+This uses FFmpeg's `silencedetect` behavior and is the stable default.
+
+### Conservative auto threshold
+
+```bash
+audio-desilencer input.ogg --threshold auto
+```
+
+Auto mode does **not** use AI, a model, training data, internet access, or a cloud service. It analyzes short peak-level windows in the recording and estimates a conservative threshold from the quieter part of the signal.
+
+Safety rules:
+
+- any loud sample on any channel makes that analysis window active
+- all channels must be quiet before a frame is considered quiet
+- auto mode never chooses a threshold more aggressive than the normal `-38 dBFS` default
+- auto mode uses 3 dB of exit hysteresis by default to avoid rapidly switching state around the threshold
+
+You can also enable hysteresis with a numeric threshold:
+
+```bash
+audio-desilencer input.ogg --threshold -38 --hysteresis_db 3
+```
+
+A numeric threshold with no `--hysteresis_db` preserves the stable FFmpeg detector path.
 
 ## CLI
 
@@ -59,7 +113,7 @@ audio-desilencer input.ogg \
   --output_format wav
 ```
 
-Use `--target_silence_len 0` to remove accepted silence completely. Keeping a small value is usually more natural for speech because edits remain inside quiet material instead of landing directly on word boundaries.
+Use `--target_silence_len 0` to remove accepted silence completely. Keeping a small value is usually more natural because edits remain inside quiet material instead of landing directly on word boundaries.
 
 Optional custom output stem:
 
@@ -76,9 +130,39 @@ interview_silent_parts.txt
 interview_non_silent_parts.txt
 ```
 
-`*_non_silent` is the desilenced recording. It still contains the small amount of pause requested by `target_silence_len`.
+`*_non_silent.wav` is the desilenced recording. It still contains the amount of pause requested by `target_silence_len`.
 
-`*_silent` contains only the material actually removed from the source, not every low-energy sample detected near speech boundaries.
+`*_silent.wav` is an **inspection artifact** containing only the removed ranges concatenated together. It is not intended to sound like a natural continuous recording.
+
+## Choosing settings
+
+A practical starting point for voice recordings:
+
+```text
+--threshold -38
+--min_silence_len 700
+--target_silence_len 150
+```
+
+More aggressive pacing:
+
+```text
+--target_silence_len 50
+```
+
+More natural pacing:
+
+```text
+--target_silence_len 250
+```
+
+If the recording level/noise floor varies and you do not want to choose a threshold manually:
+
+```text
+--threshold auto
+```
+
+If quiet speech is ever being classified as silence, make the threshold **lower/more negative**, for example `-42`, or use `auto`. If too little silence is detected, raise it cautiously.
 
 ## Python API
 
@@ -95,24 +179,36 @@ result = processor.process_audio(
 )
 
 print(result.detected_silence_ranges)
-print(result.silent_ranges)       # ranges actually removed
-print(result.non_silent_ranges)   # source ranges retained in the output
+print(result.silent_ranges)              # source ranges actually removed
+print(result.non_silent_ranges)          # source ranges retained
+print(result.resolved_threshold_dbfs)    # useful with threshold="auto"
+print(result.detector)                    # ffmpeg / adaptive / hysteresis
 print(result.non_silent_audio_path)
 ```
 
-The legacy detection method remains available:
+Auto mode:
 
 ```python
-non_silent_source_ranges = processor.split_audio_by_silence(
+result = processor.process_audio(
+    threshold="auto",
+    min_silence_len=700,
+    target_silence_len=150,
+)
+```
+
+Direct detection remains available:
+
+```python
+silent_ranges = processor.detect_silence_ranges(
     min_silence_len=700,
     threshold=-38,
 )
 ```
 
-For direct silence inspection:
+The backward-compatible non-silent range API is also available:
 
 ```python
-silent_ranges = processor.detect_silence_ranges(
+non_silent_source_ranges = processor.split_audio_by_silence(
     min_silence_len=700,
     threshold=-38,
 )
@@ -128,13 +224,13 @@ Timeline files contain Python-literal `(start_ms, end_ms)` tuples in **source ti
 
 - `silent_parts.txt` contains ranges actually removed.
 - `non_silent_parts.txt` contains source ranges retained in the desilenced output.
-- `ProcessingResult.detected_silence_ranges` exposes the full silence regions detected before pause shortening.
+- `ProcessingResult.detected_silence_ranges` exposes full silence regions before pause shortening.
 
 ## Signal preservation
 
 Audio DeSilencer deliberately performs no gain or tone processing.
 
-The FFmpeg render graph only uses timing operations:
+The render graph only uses timing operations:
 
 ```text
 atrim -> timestamp reset -> concat
@@ -144,6 +240,16 @@ For WAV output, the package writes 32-bit floating-point PCM. This preserves ove
 
 Lossy formats such as MP3 must be re-encoded and therefore cannot be sample-identical to the source. Use WAV when validating editing quality or when you want a lossless intermediate.
 
+## Stereo and multichannel policy
+
+Silence removal is conservative across channels.
+
+A section is considered quiet only when **all channels are quiet**. Activity on one channel protects that interval from removal. This avoids deleting material from stereo recordings where only one side contains useful audio.
+
+## Large recordings
+
+Recordings with many detected pauses can produce very large FFmpeg filter graphs. Audio DeSilencer automatically moves large graphs into a temporary FFmpeg filter-script file instead of placing the entire graph on the operating-system command line. The temporary file is removed after rendering.
+
 ## Architecture
 
 ```text
@@ -152,7 +258,8 @@ CLI / Python caller
         ▼
 AudioProcessor
 ├── ffprobe source metadata
-├── FFmpeg continuous-silence detection
+├── fixed FFmpeg silence detection
+│      OR deterministic peak/hysteresis analysis
 ├── normalize detected ranges
 ├── build removal ranges from the middle of silence
 ├── compute retained source ranges
@@ -161,7 +268,7 @@ AudioProcessor
 └── write source-time timelines
 ```
 
-This avoids the previous architecture of extracting independent speech chunks and blindly joining their raw PCM bytes at detector boundaries.
+The detector decides **where editing is safe**. The renderer does not attempt to repair bad detection by processing the voice.
 
 ## Testing
 
@@ -174,10 +281,14 @@ The regression suite covers:
 - leading, internal, and trailing silence
 - fully silent and fully non-silent files
 - conservative middle-of-pause removal
+- fixed and deterministic auto detection
+- hysteresis behavior
+- stereo channel-safety behavior
 - source/removed/retained range semantics
 - real FFmpeg silence detection on synthetic audio
 - over-range float WAV preservation
 - byte-for-byte equality of retained decoded PCM on lossless fixtures
+- large edit graphs / command-length safety
 - output naming and path containment
 - timeline serialization
 - CLI success/failure behavior
@@ -186,10 +297,12 @@ GitHub Actions runs the suite on Python 3.10, 3.11, 3.12, and 3.13 and separatel
 
 ## Scope / limitations
 
-- Detection is threshold-based, deterministic, and explainable; it is not semantic voice-activity detection.
-- Thresholds still need to match the recording environment. Quiet speech below the selected threshold can still be classified as silence, so conservative settings are recommended.
+- Fixed and auto detection are deterministic signal analysis, not semantic voice-activity detection.
+- Auto mode is deliberately conservative and may leave more silence rather than risk removing quiet speech.
+- A very noisy recording may still require a manually chosen threshold.
 - The current production path does not normalize loudness or repair already-clipped source audio by design.
 - FFmpeg codec support depends on the FFmpeg build installed on the host.
+- No ML/VAD dependency is bundled. A future optional voice-specific guard can be added without changing the non-destructive renderer.
 
 ## License
 

--- a/audio_desilencer/__init__.py
+++ b/audio_desilencer/__init__.py
@@ -3,6 +3,8 @@ from .audio_processor import (
     ProcessingResult,
     build_removal_ranges,
     complement_ranges,
+    detect_silence_from_levels,
+    estimate_adaptive_threshold,
 )
 
 __all__ = [
@@ -10,4 +12,6 @@ __all__ = [
     "ProcessingResult",
     "build_removal_ranges",
     "complement_ranges",
+    "detect_silence_from_levels",
+    "estimate_adaptive_threshold",
 ]

--- a/audio_desilencer/audio_processor.py
+++ b/audio_desilencer/audio_processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import array
 import json
 import math
 import os
@@ -8,12 +9,20 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Sequence
 
 
 Timeline = list[tuple[int, int]]
+Threshold = float | str
+
+DEFAULT_THRESHOLD_DBFS = -38.0
+DEFAULT_MIN_SILENCE_MS = 700
+DEFAULT_TARGET_SILENCE_MS = 150
+DEFAULT_AUTO_HYSTERESIS_DB = 3.0
+ANALYSIS_WINDOW_MS = 20
 
 
 @dataclass(frozen=True)
@@ -25,6 +34,8 @@ class ProcessingResult:
     silent_ranges: tuple[tuple[int, int], ...]
     non_silent_ranges: tuple[tuple[int, int], ...]
     detected_silence_ranges: tuple[tuple[int, int], ...] = ()
+    resolved_threshold_dbfs: float | None = None
+    detector: str = "ffmpeg"
 
 
 @dataclass(frozen=True)
@@ -82,13 +93,7 @@ def build_removal_ranges(
     detected_silence_ranges: Iterable[Sequence[int]],
     target_silence_len: int,
 ) -> Timeline:
-    """Return only the middle portions of confirmed silence that are safe to delete.
-
-    Internal pauses are shortened to ``target_silence_len`` total, split across both
-    sides of the cut so speech retains its natural low-level lead-in and tail. Leading
-    and trailing silence retain half that amount next to speech. A completely silent
-    file is removed in full from the non-silent output.
-    """
+    """Return only the middle portions of confirmed silence that are safe to delete."""
     total = max(0, int(total_duration))
     target = int(target_silence_len)
     if target < 0:
@@ -119,12 +124,118 @@ def build_removal_ranges(
     return _normalize_ranges(removals, total)
 
 
+def estimate_adaptive_threshold(
+    frame_levels_dbfs: Sequence[float],
+    *,
+    percentile: float = 0.35,
+    margin_db: float = 8.0,
+    minimum_dbfs: float = -55.0,
+    maximum_dbfs: float = DEFAULT_THRESHOLD_DBFS,
+) -> float:
+    """Estimate a conservative silence threshold from short-window peak levels.
+
+    This is deterministic signal analysis, not a learned model. The lower-level
+    portion of the recording is treated as a noise-floor estimate and a small
+    margin is added. Auto mode is deliberately conservative: by default it will
+    never choose a threshold more aggressive than the normal -38 dBFS default.
+    """
+    if not frame_levels_dbfs:
+        return DEFAULT_THRESHOLD_DBFS
+    if not 0.0 <= percentile <= 1.0:
+        raise ValueError("percentile must be between zero and one")
+    if minimum_dbfs > maximum_dbfs:
+        raise ValueError("minimum_dbfs cannot exceed maximum_dbfs")
+
+    levels = sorted(
+        max(-120.0, min(0.0, float(level)))
+        for level in frame_levels_dbfs
+        if math.isfinite(float(level))
+    )
+    if not levels:
+        return DEFAULT_THRESHOLD_DBFS
+
+    index = int((len(levels) - 1) * percentile)
+    noise_floor = levels[index]
+    threshold = noise_floor + float(margin_db)
+    return max(float(minimum_dbfs), min(float(maximum_dbfs), threshold))
+
+
+def detect_silence_from_levels(
+    frames: Sequence[tuple[int, int, float]],
+    *,
+    min_silence_len: int,
+    enter_threshold_dbfs: float,
+    hysteresis_db: float = 0.0,
+    total_duration_ms: int | None = None,
+) -> Timeline:
+    """Detect continuous silence from short-window levels with exit hysteresis."""
+    if min_silence_len <= 0:
+        raise ValueError("min_silence_len must be greater than zero")
+    if hysteresis_db < 0 or not math.isfinite(float(hysteresis_db)):
+        raise ValueError("hysteresis_db must be a finite value >= 0")
+
+    enter = float(enter_threshold_dbfs)
+    if not math.isfinite(enter):
+        raise ValueError("enter_threshold_dbfs must be finite")
+    exit_threshold = enter + float(hysteresis_db)
+
+    ranges: Timeline = []
+    candidate_start: int | None = None
+    silence_start: int | None = None
+    in_silence = False
+    last_end = 0
+
+    for raw_start, raw_end, raw_level in frames:
+        start = max(0, int(raw_start))
+        end = max(start, int(raw_end))
+        level = float(raw_level)
+        last_end = max(last_end, end)
+
+        if not in_silence:
+            if level <= enter:
+                if candidate_start is None:
+                    candidate_start = start
+                if end - candidate_start >= min_silence_len:
+                    in_silence = True
+                    silence_start = candidate_start
+            else:
+                candidate_start = None
+            continue
+
+        if level > exit_threshold:
+            if silence_start is not None and start > silence_start:
+                ranges.append((silence_start, start))
+            in_silence = False
+            silence_start = None
+            candidate_start = None
+
+    if in_silence and silence_start is not None:
+        final_end = int(total_duration_ms) if total_duration_ms is not None else last_end
+        if final_end > silence_start:
+            ranges.append((silence_start, final_end))
+
+    total = int(total_duration_ms) if total_duration_ms is not None else last_end
+    return _normalize_ranges(ranges, total)
+
+
+def _parse_threshold(value: str) -> Threshold:
+    if value.strip().lower() == "auto":
+        return "auto"
+    try:
+        result = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("threshold must be a dBFS number or 'auto'") from exc
+    if not math.isfinite(result):
+        raise argparse.ArgumentTypeError("threshold must be finite")
+    return result
+
+
 class AudioProcessor:
     """Non-destructive silence editor backed directly by FFmpeg.
 
-    The processor never normalizes, limits, filters, crossfades, or otherwise changes
-    retained audio. It detects sufficiently long silence, removes only the middle of
-    those pauses, and asks FFmpeg to concatenate the untouched retained source spans.
+    Retained audio is never normalized, limited, EQ'd, compressed, de-essed,
+    crossfaded, or otherwise altered. Detection may analyze decoded samples, but
+    rendering only trims time ranges and concatenates retained source spans.
     """
 
     def __init__(self, input_file_path: str | os.PathLike[str]):
@@ -181,13 +292,104 @@ class AudioProcessor:
             channel_layout=channel_layout,
         )
 
-    def detect_silence_ranges(self, min_silence_len: int = 700, threshold: float = -38.0) -> Timeline:
-        """Detect continuous silence using FFmpeg's RMS-based silencedetect filter."""
-        if min_silence_len <= 0:
-            raise ValueError("min_silence_len must be greater than zero")
-        if not math.isfinite(float(threshold)):
-            raise ValueError("threshold must be a finite dBFS value")
+    @staticmethod
+    def _coerce_threshold(threshold: Threshold) -> Threshold:
+        if isinstance(threshold, str):
+            if threshold.strip().lower() == "auto":
+                return "auto"
+            try:
+                threshold = float(threshold)
+            except ValueError as exc:
+                raise ValueError("threshold must be a finite dBFS number or 'auto'") from exc
+        value = float(threshold)
+        if not math.isfinite(value):
+            raise ValueError("threshold must be a finite dBFS number or 'auto'")
+        return value
 
+    def _measure_frame_levels(self, window_ms: int = ANALYSIS_WINDOW_MS) -> list[tuple[int, int, float]]:
+        """Measure peak level in short windows.
+
+        Any over-threshold sample on any channel makes the window active. This
+        conservative peak policy protects short consonants/transients and means a
+        frame counts as quiet only when every channel is quiet.
+        """
+        if window_ms <= 0:
+            raise ValueError("window_ms must be greater than zero")
+
+        samples_per_window = max(1, int(round(self._info.sample_rate * window_ms / 1000.0)))
+        bytes_per_sample = 4
+        frame_bytes = samples_per_window * self._info.channels * bytes_per_sample
+
+        process = subprocess.Popen(
+            [
+                "ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error",
+                "-i", self.input_file_path,
+                "-map", "0:a:0",
+                "-f", "f32le",
+                "-acodec", "pcm_f32le",
+                "pipe:1",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert process.stdout is not None
+        assert process.stderr is not None
+
+        frames: list[tuple[int, int, float]] = []
+        total_samples_per_channel = 0
+
+        try:
+            while True:
+                buffer = bytearray()
+                while len(buffer) < frame_bytes:
+                    chunk = process.stdout.read(frame_bytes - len(buffer))
+                    if not chunk:
+                        break
+                    buffer.extend(chunk)
+
+                if not buffer:
+                    break
+
+                complete_sample_bytes = (len(buffer) // (bytes_per_sample * self._info.channels)) * (
+                    bytes_per_sample * self._info.channels
+                )
+                if complete_sample_bytes == 0:
+                    break
+
+                values = array.array("f")
+                values.frombytes(buffer[:complete_sample_bytes])
+                if sys.byteorder != "little":
+                    values.byteswap()
+
+                samples_this_channel = len(values) // self._info.channels
+                max_peak = max((abs(float(value)) for value in values), default=0.0)
+                level_dbfs = 20.0 * math.log10(max_peak) if max_peak > 0.0 else -120.0
+
+                start_ms = int(round(total_samples_per_channel * 1000.0 / self._info.sample_rate))
+                total_samples_per_channel += samples_this_channel
+                end_ms = min(
+                    self._info.duration_ms,
+                    int(round(total_samples_per_channel * 1000.0 / self._info.sample_rate)),
+                )
+                frames.append((start_ms, max(start_ms, end_ms), level_dbfs))
+
+                if len(buffer) < frame_bytes:
+                    break
+
+            stderr = process.stderr.read().decode("utf-8", errors="replace")
+            return_code = process.wait()
+            if return_code != 0:
+                raise OSError(stderr.strip() or "FFmpeg level analysis failed")
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+            process.stdout.close()
+            process.stderr.close()
+
+        return frames
+
+    def _detect_silence_ffmpeg(self, min_silence_len: int, threshold: float) -> Timeline:
         duration_s = min_silence_len / 1000.0
         result = subprocess.run(
             [
@@ -229,13 +431,82 @@ class AudioProcessor:
 
         return _normalize_ranges(ranges, self._info.duration_ms)
 
-    def split_audio_by_silence(self, min_silence_len: int, threshold: float) -> Timeline:
+    def _detect_silence(
+        self,
+        min_silence_len: int,
+        threshold: Threshold,
+        hysteresis_db: float | None,
+    ) -> tuple[Timeline, float, str]:
+        threshold = self._coerce_threshold(threshold)
+        if min_silence_len <= 0:
+            raise ValueError("min_silence_len must be greater than zero")
+        if hysteresis_db is not None and (
+            not math.isfinite(float(hysteresis_db)) or float(hysteresis_db) < 0
+        ):
+            raise ValueError("hysteresis_db must be a finite value >= 0")
+
+        if threshold != "auto" and (hysteresis_db is None or float(hysteresis_db) == 0.0):
+            resolved = float(threshold)
+            return self._detect_silence_ffmpeg(min_silence_len, resolved), resolved, "ffmpeg"
+
+        frames = self._measure_frame_levels()
+        levels = [level for _, _, level in frames]
+        if threshold == "auto":
+            resolved = estimate_adaptive_threshold(levels)
+            resolved_hysteresis = (
+                DEFAULT_AUTO_HYSTERESIS_DB if hysteresis_db is None else float(hysteresis_db)
+            )
+            detector = "adaptive"
+        else:
+            resolved = float(threshold)
+            resolved_hysteresis = 0.0 if hysteresis_db is None else float(hysteresis_db)
+            detector = "hysteresis"
+
+        ranges = detect_silence_from_levels(
+            frames,
+            min_silence_len=min_silence_len,
+            enter_threshold_dbfs=resolved,
+            hysteresis_db=resolved_hysteresis,
+            total_duration_ms=self._info.duration_ms,
+        )
+        return ranges, resolved, detector
+
+    def detect_silence_ranges(
+        self,
+        min_silence_len: int = DEFAULT_MIN_SILENCE_MS,
+        threshold: Threshold = DEFAULT_THRESHOLD_DBFS,
+        hysteresis_db: float | None = None,
+    ) -> Timeline:
+        """Detect continuous silence.
+
+        Numeric thresholds with no hysteresis preserve the established FFmpeg
+        silencedetect behavior. ``threshold="auto"`` enables deterministic
+        noise-floor estimation and 3 dB exit hysteresis by default.
+        """
+        ranges, _, _ = self._detect_silence(min_silence_len, threshold, hysteresis_db)
+        return ranges
+
+    def split_audio_by_silence(
+        self,
+        min_silence_len: int,
+        threshold: Threshold,
+        hysteresis_db: float | None = None,
+    ) -> Timeline:
         """Backward-compatible detection API returning non-silent source ranges."""
-        silent = self.detect_silence_ranges(min_silence_len=min_silence_len, threshold=threshold)
+        silent = self.detect_silence_ranges(
+            min_silence_len=min_silence_len,
+            threshold=threshold,
+            hysteresis_db=hysteresis_db,
+        )
         return complement_ranges(self._info.duration_ms, silent)
 
-    def is_fully_silent(self, min_silence_len: int = 700, threshold: float = -38.0) -> bool:
-        return not self.split_audio_by_silence(min_silence_len, threshold)
+    def is_fully_silent(
+        self,
+        min_silence_len: int = DEFAULT_MIN_SILENCE_MS,
+        threshold: Threshold = DEFAULT_THRESHOLD_DBFS,
+        hysteresis_db: float | None = None,
+    ) -> bool:
+        return not self.split_audio_by_silence(min_silence_len, threshold, hysteresis_db)
 
     def save_timeline_to_text(self, timeline_data: Iterable[Sequence[int]], output_path: str) -> None:
         timeline = [(int(start), int(end)) for start, end in timeline_data]
@@ -278,24 +549,45 @@ class AudioProcessor:
             output_label = labels[0]
         else:
             output_label = "[outa]"
-            filter_complex = ";".join(filters) + ";" + "".join(labels) + f"concat=n={len(labels)}:v=0:a=1{output_label}"
+            filter_complex = ";".join(filters) + ";" + "".join(labels) + (
+                f"concat=n={len(labels)}:v=0:a=1{output_label}"
+            )
 
         command = [
             "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
             "-i", self.input_file_path,
-            "-filter_complex", filter_complex,
-            "-map", output_label,
         ]
-        if output_format == "wav":
-            command += ["-c:a", "pcm_f32le"]
-        command.append(str(output_path))
-        self._run(command)
+
+        script_path: Path | None = None
+        try:
+            if len(filter_complex) > 8000:
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    encoding="utf-8",
+                    suffix=".ffscript",
+                    delete=False,
+                ) as script:
+                    script.write(filter_complex)
+                    script_path = Path(script.name)
+                command += ["-filter_complex_script", str(script_path)]
+            else:
+                command += ["-filter_complex", filter_complex]
+
+            command += ["-map", output_label]
+            if output_format == "wav":
+                command += ["-c:a", "pcm_f32le"]
+            command.append(str(output_path))
+            self._run(command)
+        finally:
+            if script_path is not None:
+                script_path.unlink(missing_ok=True)
 
     def process_audio(
         self,
-        min_silence_len: int = 700,
-        threshold: float = -38.0,
-        target_silence_len: int = 150,
+        min_silence_len: int = DEFAULT_MIN_SILENCE_MS,
+        threshold: Threshold = DEFAULT_THRESHOLD_DBFS,
+        target_silence_len: int = DEFAULT_TARGET_SILENCE_MS,
+        hysteresis_db: float | None = None,
         output_folder: str | os.PathLike[str] = "output",
         output_format: str = "wav",
         output_stem: str | None = None,
@@ -304,15 +596,22 @@ class AudioProcessor:
             raise ValueError("min_silence_len must be greater than zero")
         if target_silence_len < 0:
             raise ValueError("target_silence_len must be zero or greater")
-        if not math.isfinite(float(threshold)):
-            raise ValueError("threshold must be a finite dBFS value")
+        threshold = self._coerce_threshold(threshold)
+        if hysteresis_db is not None and (
+            not math.isfinite(float(hysteresis_db)) or float(hysteresis_db) < 0
+        ):
+            raise ValueError("hysteresis_db must be a finite value >= 0")
 
         normalized_format = output_format.strip().lower()
         if not re.fullmatch(r"[a-z0-9]+", normalized_format):
             raise ValueError("output_format must be a simple format name such as 'mp3' or 'wav'")
 
         print("Processing audio...")
-        detected_silence_ranges = self.detect_silence_ranges(min_silence_len, threshold)
+        detected_silence_ranges, resolved_threshold, detector = self._detect_silence(
+            min_silence_len,
+            threshold,
+            hysteresis_db,
+        )
         removed_ranges = build_removal_ranges(
             self._info.duration_ms,
             detected_silence_ranges,
@@ -337,7 +636,10 @@ class AudioProcessor:
         self.save_timeline_to_text(removed_ranges, str(silent_timeline_path))
         self.save_timeline_to_text(retained_ranges, str(non_silent_timeline_path))
 
-        print("Audio processing completed.")
+        print(
+            f"Audio processing completed. detector={detector}, "
+            f"threshold={resolved_threshold:.2f} dBFS"
+        )
         return ProcessingResult(
             silent_audio_path=str(silent_audio_path),
             non_silent_audio_path=str(non_silent_audio_path),
@@ -346,6 +648,8 @@ class AudioProcessor:
             silent_ranges=tuple(removed_ranges),
             non_silent_ranges=tuple(retained_ranges),
             detected_silence_ranges=tuple(detected_silence_ranges),
+            resolved_threshold_dbfs=resolved_threshold,
+            detector=detector,
         )
 
 
@@ -353,12 +657,28 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Remove long silence without processing retained audio")
     parser.add_argument("input_file", help="Input audio file path")
     parser.add_argument("--output_folder", default="output", help="Output folder path")
-    parser.add_argument("--min_silence_len", type=int, default=700, help="Minimum continuous silence in milliseconds")
-    parser.add_argument("--threshold", type=float, default=-38.0, help="Silence threshold in dBFS")
+    parser.add_argument(
+        "--min_silence_len",
+        type=int,
+        default=DEFAULT_MIN_SILENCE_MS,
+        help="Minimum continuous silence in milliseconds",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=_parse_threshold,
+        default=DEFAULT_THRESHOLD_DBFS,
+        help="Silence threshold in dBFS, or 'auto' for deterministic noise-floor estimation",
+    )
+    parser.add_argument(
+        "--hysteresis_db",
+        type=float,
+        default=None,
+        help="Optional dB gap required to leave silence; auto mode defaults to 3 dB",
+    )
     parser.add_argument(
         "--target_silence_len",
         type=int,
-        default=150,
+        default=DEFAULT_TARGET_SILENCE_MS,
         help="Silence to keep for each internal pause in milliseconds",
     )
     parser.add_argument("--output_format", default="wav", help="Output audio format (default: wav)")
@@ -376,6 +696,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             min_silence_len=args.min_silence_len,
             threshold=args.threshold,
             target_silence_len=args.target_silence_len,
+            hysteresis_db=args.hysteresis_db,
             output_folder=args.output_folder,
             output_format=args.output_format,
             output_stem=args.output_stem,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as readme_file:
 
 setup(
     name="Audio-DeSilencer",
-    version="1.0.3",
+    version="1.1.0",
     description="A non-destructive FFmpeg-backed silence remover for speech and general audio.",
     author="Boutros Tawaifi",
     author_email="boutrous.m.tawaifi@gmail.com",

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -15,6 +15,8 @@ from audio_desilencer.audio_processor import (
     _normalize_ranges,
     build_removal_ranges,
     complement_ranges,
+    detect_silence_from_levels,
+    estimate_adaptive_threshold,
     main,
 )
 import audio_desilencer.audio_processor as module
@@ -36,6 +38,20 @@ def write_test_wav(path: Path, sections, sample_rate: int = 8000) -> None:
         handle.setsampwidth(2)
         handle.setframerate(sample_rate)
         handle.writeframes(struct.pack(f"<{len(samples)}h", *samples))
+
+
+def write_stereo_test_wav(path: Path, left_amp: float, right_amp: float, duration_ms: int = 500, sample_rate: int = 8000):
+    frames = []
+    count = int(sample_rate * duration_ms / 1000)
+    for index in range(count):
+        left = int(32767 * left_amp * math.sin(2 * math.pi * 440 * index / sample_rate)) if left_amp else 0
+        right = int(32767 * right_amp * math.sin(2 * math.pi * 440 * index / sample_rate)) if right_amp else 0
+        frames.extend((left, right))
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(2)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(struct.pack(f"<{len(frames)}h", *frames))
 
 
 def decode_f32(path: Path) -> bytes:
@@ -76,6 +92,48 @@ class RangeTests(unittest.TestCase):
             build_removal_ranges(1000, [(0, 500)], -1)
 
 
+class DeterministicDetectorTests(unittest.TestCase):
+    def test_adaptive_threshold_uses_quiet_percentile_and_bounds(self):
+        levels = [-52.0] * 40 + [-20.0] * 60
+        self.assertAlmostEqual(estimate_adaptive_threshold(levels), -44.0)
+        self.assertEqual(estimate_adaptive_threshold([-100.0] * 100), -55.0)
+        self.assertEqual(estimate_adaptive_threshold([-31.0] * 100), -38.0)
+
+    def test_hysteresis_prevents_threshold_flutter_from_ending_silence(self):
+        frames = [
+            (0, 20, -45.0),
+            (20, 40, -44.0),
+            (40, 60, -39.0),
+            (60, 80, -37.0),
+            (80, 100, -40.0),
+            (100, 120, -20.0),
+        ]
+        ranges = detect_silence_from_levels(
+            frames,
+            min_silence_len=40,
+            enter_threshold_dbfs=-38.0,
+            hysteresis_db=3.0,
+            total_duration_ms=120,
+        )
+        self.assertEqual(ranges, [(0, 100)])
+
+    def test_unconfirmed_quiet_run_is_not_bridged_by_hysteresis(self):
+        frames = [
+            (0, 20, -45.0),
+            (20, 40, -30.0),
+            (40, 60, -45.0),
+            (60, 80, -45.0),
+        ]
+        ranges = detect_silence_from_levels(
+            frames,
+            min_silence_len=40,
+            enter_threshold_dbfs=-38.0,
+            hysteresis_db=3.0,
+            total_duration_ms=80,
+        )
+        self.assertEqual(ranges, [(40, 80)])
+
+
 class AudioProcessorTests(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -101,6 +159,37 @@ class AudioProcessorTests(unittest.TestCase):
         self.assertEqual(len(nonsilent), 1)
         self.assertLessEqual(abs(nonsilent[0][0] - 200), 10)
         self.assertLessEqual(abs(nonsilent[0][1] - 500), 10)
+
+    def test_adaptive_detection_is_deterministic_and_reports_resolved_threshold(self):
+        source = self.root / "adaptive.wav"
+        write_test_wav(source, [
+            (800, 0.003, 120),
+            (400, 0.7, 440),
+            (800, 0.003, 120),
+        ])
+        processor = AudioProcessor(source)
+        result = processor.process_audio(
+            min_silence_len=500,
+            threshold="auto",
+            target_silence_len=100,
+            output_folder=self.root / "adaptive_out",
+            output_format="wav",
+        )
+        self.assertEqual(result.detector, "adaptive")
+        self.assertIsNotNone(result.resolved_threshold_dbfs)
+        self.assertLessEqual(result.resolved_threshold_dbfs, -38.0)
+        self.assertGreater(len(result.detected_silence_ranges), 0)
+
+    def test_stereo_policy_requires_all_channels_to_be_quiet(self):
+        source = self.root / "stereo.wav"
+        write_stereo_test_wav(source, left_amp=0.0, right_amp=0.8)
+        processor = AudioProcessor(source)
+        fixed = processor.detect_silence_ranges(min_silence_len=100, threshold=-30)
+        self.assertEqual(fixed, [])
+
+        frames = processor._measure_frame_levels()
+        self.assertTrue(frames)
+        self.assertGreater(max(level for _, _, level in frames), -10.0)
 
     def test_is_fully_silent_and_non_silent(self):
         silent_path = self.root / "silent.wav"
@@ -132,6 +221,8 @@ class AudioProcessorTests(unittest.TestCase):
         self.assertEqual(result.silent_ranges, ((0, 150), (550, 1450), (1850, 2000)))
         self.assertEqual(result.non_silent_ranges, ((150, 550), (1450, 1850)))
         self.assertEqual(result.detected_silence_ranges, ((0, 200), (500, 1500), (1800, 2000)))
+        self.assertEqual(result.detector, "ffmpeg")
+        self.assertEqual(result.resolved_threshold_dbfs, -30.0)
         self.assertTrue(Path(result.non_silent_audio_path).is_file())
         self.assertTrue(Path(result.silent_audio_path).is_file())
 
@@ -184,6 +275,19 @@ class AudioProcessorTests(unittest.TestCase):
         for actual, expected in zip(decoded[:5], values[:5]):
             self.assertAlmostEqual(actual, expected, places=6)
 
+    def test_large_edit_graph_uses_filter_script_to_avoid_command_length_limits(self):
+        source = self.root / "long.wav"
+        write_test_wav(source, [(10000, 0.5, 440)])
+        processor = AudioProcessor(source)
+        ranges = [(index * 40, index * 40 + 20) for index in range(200)]
+        output = self.root / "many.wav"
+        with patch.object(processor, "_run") as run:
+            processor._render_ranges(ranges, output, "wav")
+        command = run.call_args.args[0]
+        self.assertIn("-filter_complex_script", command)
+        script_index = command.index("-filter_complex_script") + 1
+        self.assertFalse(Path(command[script_index]).exists(), "temporary filter script should be cleaned up")
+
     def test_process_custom_stem_cannot_escape_output_directory(self):
         source = self.root / "input.wav"
         write_test_wav(source, [(300, 0.8, 440)])
@@ -205,6 +309,10 @@ class AudioProcessorTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             processor.process_audio(target_silence_len=-1)
         with self.assertRaises(ValueError):
+            processor.process_audio(hysteresis_db=-1)
+        with self.assertRaises(ValueError):
+            processor.process_audio(threshold="banana")
+        with self.assertRaises(ValueError):
             processor.process_audio(output_format="../mp3")
 
     def test_save_timeline_writes_valid_python_literal(self):
@@ -224,7 +332,8 @@ class CliTests(unittest.TestCase):
             "input.wav",
             "--output_folder", "out",
             "--min_silence_len", "700",
-            "--threshold", "-38",
+            "--threshold", "auto",
+            "--hysteresis_db", "4",
             "--target_silence_len", "120",
             "--output_format", "wav",
             "--output_stem", "cleaned",
@@ -233,8 +342,9 @@ class CliTests(unittest.TestCase):
         processor_cls.assert_called_once_with("input.wav")
         processor.process_audio.assert_called_once_with(
             min_silence_len=700,
-            threshold=-38.0,
+            threshold="auto",
             target_silence_len=120,
+            hysteresis_db=4.0,
             output_folder="out",
             output_format="wav",
             output_stem="cleaned",


### PR DESCRIPTION
## Summary
- keep the known-good fixed `-38 dBFS` FFmpeg detector as the default path
- add opt-in deterministic `--threshold auto` analysis with conservative peak windows and exit hysteresis
- add optional `--hysteresis_db` for numeric thresholds
- make stereo/multichannel detection conservative: activity on any channel protects the interval
- fall back to FFmpeg filter-script files for very large edit graphs / command-line length safety
- expose resolved threshold + detector in `ProcessingResult`
- bump package version to 1.1.0
- add CHANGELOG and expand README with FFmpeg install, tuning, `_silent.wav` inspection-artifact warning, multichannel and large-file behavior

## Safety / compatibility
- no model, VAD, training data, internet service, or cloud dependency
- default numeric threshold path is unchanged
- retained audio rendering remains timing-only (`atrim` / timestamp reset / concat)
- no normalization, limiting, EQ, fades, crossfades, compression, or gain changes
- auto mode never chooses a threshold more aggressive than the stable -38 dBFS default

## Validation
- local regression suite: 24/24 passing
- fixed default path on the supplied WhatsApp Opus fixture produces the exact same decoded non-silent WAV bytes as the current main output
- auto mode uses peak rather than RMS windows so short loud consonant/transient samples break silence instead of being averaged away
